### PR TITLE
podman_image: only set changed=true if there is a new image

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -424,19 +424,26 @@ class PodmanImageManager(object):
     def present(self):
         image = self.find_image()
 
+        if image:
+            digest_before = image[0].get('Digest', image[0].get('digest'))
+        else:
+            digest_before = None
+
         if not image or self.force:
             if self.path:
                 # Build the image
                 self.results['actions'].append('Built image {image_name} from {path}'.format(image_name=self.image_name, path=self.path))
-                self.results['changed'] = True
                 if not self.module.check_mode:
                     self.results['image'] = self.build_image()
             else:
                 # Pull the image
                 self.results['actions'].append('Pulled image {image_name}'.format(image_name=self.image_name))
-                self.results['changed'] = True
                 if not self.module.check_mode:
                     self.results['image'] = self.pull_image()
+
+            image = self.find_image()
+            digest_after = image[0].get('Digest', image[0].get('digest'))
+            self.results['changed'] = digest_before != digest_after
 
         if self.push:
             # Push the image


### PR DESCRIPTION
with force: true, podman_image would always report changed regardless
of whether or not the pull or build operation resulted in a new image.
With this commit, check the image digest before and after and only
reported changed if the digest is different.

I'm relocating this from https://github.com/ansible/ansible/pull/68542