### PR TITLE
podman_image: use correct option for remove_signatures flag

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -583,7 +583,7 @@ class PodmanImageManager(object):
             args.extend(['--format', push_format])
 
         if self.push_args.get('remove_signatures'):
-            args.append('--remove_signatures')
+            args.append('--remove-signatures')
 
         sign_by_key = self.push_args.get('sign_by')
         if sign_by_key:


### PR DESCRIPTION
##### SUMMARY

podman_image module uses 'podman push' command with wrong
flag '--remove_signatures' instead of '--remove-signatures'

This patch fixes the given typo.

Fixes: ansible/ansible#67965

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/podman_image.py
