### PR TITLE
Run pause=false w/o message condition

### DIFF
--- a/plugins/connection/podman.py
+++ b/plugins/connection/podman.py
@@ -166,15 +166,14 @@ class Connection(ConnectionBase):
                 "cp", [in_path, self._container_id + ":" + out_path], use_container_id=False
             )
             if rc != 0:
-                if 'cannot copy into running rootless container with pause set' in to_native(stderr):
-                    rc, stdout, stderr = self._podman(
-                        "cp", ["--pause=false", in_path, self._container_id + ":" + out_path], use_container_id=False
+                rc, stdout, stderr = self._podman(
+                    "cp", ["--pause=false", in_path, self._container_id + ":" + out_path], use_container_id=False
+                )
+                if rc != 0:
+                    raise AnsibleError(
+                        "Failed to copy file from %s to %s in container %s\n%s" % (
+                            in_path, out_path, self._container_id, stderr)
                     )
-                    if rc != 0:
-                        raise AnsibleError(
-                            "Failed to copy file from %s to %s in container %s\n%s" % (
-                                in_path, out_path, self._container_id, stderr)
-                        )
         else:
             real_out_path = self._mount_point + to_bytes(out_path, errors='surrogate_or_strict')
             shutil.copyfile(


### PR DESCRIPTION
Fixes #29 
Sometimes container fails to copy in rootless mode and the message is different, so try to set pause=false w/o depending on the error string.