### PR TITLE
Fix idempotency issues with workdir and volumes

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -1291,8 +1291,6 @@ class PodmanDefaults:
             "tty": False,
             "user": "",
             "uts": "",
-            "volume": [],
-            "workdir": "/",
         }
 
     def default_dict(self):
@@ -1654,7 +1652,10 @@ class PodmanContainerDiff:
                     volumes.append([m['source'], m['destination']])
             before = [":".join(v) for v in volumes]
         # Ignore volumes option for idempotency
-        after = [":".join(v.split(":")[:2]) for v in self.params['volume']]
+        if self.params['volume'] is not None:
+            after = [":".join(v.split(":")[:2]) for v in self.params['volume']]
+        else:
+            after = before
         before, after = sorted(list(set(before))), sorted(list(set(after)))
         return self._diff_update_and_compare('volume', before, after)
 
@@ -1665,7 +1666,10 @@ class PodmanContainerDiff:
 
     def diffparam_workdir(self):
         before = self.info['config']['workingdir']
-        after = self.params['workdir']
+        if self.params['workdir'] is not None:
+            after = self.params['workdir']
+        else:
+            after = before
         return self._diff_update_and_compare('workdir', before, after)
 
     def is_different(self):


### PR DESCRIPTION
Partially solves issues from #21, #31 
Fixes #20 
`workdir` and `volumes` can be set in the image, so for better idempotency we'll need to inspect image. For now ignore these settings if they're not set.