### PR TITLE
Improve idempotency of podman_container

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -1295,6 +1295,10 @@ class PodmanDefaults:
 
     def default_dict(self):
         # make here any changes to self.defaults related to podman version
+        # https://github.com/containers/libpod/pull/5669
+        if (LooseVersion(self.version) >= LooseVersion('1.8.0')
+                and LooseVersion(self.version) < LooseVersion('1.9.0')):
+            self.defaults['cpu_shares'] = 1024
         return self.defaults
 
 
@@ -1534,6 +1538,8 @@ class PodmanContainerDiff:
     def diffparam_ipc(self):
         before = self.info['hostconfig']['ipcmode']
         after = self.params['ipc']
+        if self.params['pod'] and not after:
+            after = before
         return self._diff_update_and_compare('ipc', before, after)
 
     def diffparam_label(self):
@@ -1583,6 +1589,8 @@ class PodmanContainerDiff:
     def diffparam_network(self):
         before = [self.info['hostconfig']['networkmode']]
         after = self.params['network']
+        if self.params['pod'] and not self.module.params['network']:
+            after = before
         return self._diff_update_and_compare('network', before, after)
 
     def diffparam_no_hosts(self):
@@ -1639,6 +1647,8 @@ class PodmanContainerDiff:
     def diffparam_uts(self):
         before = self.info['hostconfig']['utsmode']
         after = self.params['uts']
+        if self.params['pod'] and not after:
+            after = before
         return self._diff_update_and_compare('uts', before, after)
 
     def diffparam_volume(self):
@@ -1666,9 +1676,8 @@ class PodmanContainerDiff:
 
     def diffparam_workdir(self):
         before = self.info['config']['workingdir']
-        if self.params['workdir'] is not None:
-            after = self.params['workdir']
-        else:
+        after = self.params['workdir']
+        if after is None:
             after = before
         return self._diff_update_and_compare('workdir', before, after)
 

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -376,6 +376,51 @@
         that:
           - "'podman rm -f testidem' in remove.podman_actions"
 
+    # - name: Create a pod
+    #   shell: podman pod create --name testidempod
+
+    - name: Check basic idempotency of pod container
+      containers.podman.podman_container:
+        name: testidem-pod
+        image: docker.io/alpine
+        state: present
+        command: sleep 20m
+        pod: "new:testidempod"
+
+    - name: Check basic idempotency of pod container - run it again
+      containers.podman.podman_container:
+        name: testidem-pod
+        image: alpine:latest
+        state: present
+        command: sleep 20m
+        pod: testidempod
+      register: idem
+
+    - name: Check that nothing was changed in pod containers
+      assert:
+        that:
+          - not idem.changed
+
+    - name: Run changed pod container (with tty enabled)
+      containers.podman.podman_container:
+        name: testidem-pod
+        image: alpine
+        state: present
+        command: sleep 20m
+        tty: true
+        pod: testidempod
+      register: idem1
+
+    - name: Check that container is recreated when changed
+      assert:
+        that:
+          - idem1 is changed
+
+    - name: Remove container
+      containers.podman.podman_container:
+        name: testidem-pod
+        state: absent
+
   always:
     - name: Delete all container leftovers from tests
       containers.podman.podman_container:
@@ -385,3 +430,6 @@
         - "alpine:3.7"
         - "container"
         - "container2"
+
+    - name: Remove pod
+      shell: podman pod rm -f testidempod


### PR DESCRIPTION
Consider pod container differences, they change utc, network, ipc according to their pods.
Add different default for cpu_shares on podman 1.8.* versions
Add test for containers idempotency in pods
Partially solves #21 and #31