### PR TITLE
buildah/connection add support of specific user

### DIFF
--- a/tests/integration/targets/connection_buildah/runme.sh
+++ b/tests/integration/targets/connection_buildah/runme.sh
@@ -12,8 +12,13 @@ function run_ansible {
 
 }
 
+# First run as root
 run_ansible "$@"
 
-ANSIBLE_VERBOSITY=4 ANSIBLE_REMOTE_USER="1000" run_ansible "$@" | tee check_log
+# Create a normal user
+${SUDO:-} ansible all -i "test_connection.inventory" -m "user" -a 'name="testuser"'
+
+# Second run as normal user
+ANSIBLE_VERBOSITY=4 ANSIBLE_REMOTE_USER="testuser" run_ansible "$@" | tee check_log
 ${SUDO:-} grep -q "Using buildah connection from collection" check_log
 ${SUDO:-} rm -f check_log


### PR DESCRIPTION
Add possibility to use a specific user, either defined by --user argument on
command line, or ansible_user, to connect to containers.

It is inspired from
https://github.com/containers/ansible-podman-collections/pull/19 the equivalent
for podman connection.

It was laso required to change the method to put file, from a mount mechanism,
to the buildah copy function, to allow to set correctly the permissions of
pushed files.

Fixes:  containers/ansible-podman-collections#25