### PR TITLE
Add check for empty dir for podman connection mount

### DIFF
--- a/plugins/connection/podman.py
+++ b/plugins/connection/podman.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import distutils.spawn
+import os
 import shlex
 import shutil
 import subprocess
@@ -141,6 +142,9 @@ class Connection(ConnectionBase):
         rc, self._mount_point, stderr = self._podman("mount")
         if rc != 0:
             display.v("Failed to mount container %s: %s" % (self._container_id, stderr.strip()))
+        elif not os.listdir(self._mount_point.strip()):
+            display.v("Failed to mount container with CGroups2: empty dir %s" % self._mount_point.strip())
+            self._mount_point = None
         else:
             self._mount_point = self._mount_point.strip()
             display.vvvvv("MOUNTPOINT %s RC %s STDERR %r" % (self._mount_point, rc, stderr))


### PR DESCRIPTION
Workaround for issue https://github.com/containers/libpod/issues/6856
When podman runs with CGroups v2 and rootless container,
it mounts directory without error, but mounted directory is empty.
Add check for the directory if it's empty.
Fix #70 
Let's revert it when podman will be fixed, see issue https://github.com/containers/libpod/issues/6856