### PR TITLE
Improve idempotency for volumes with slashes

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -1744,6 +1744,10 @@ class PodmanContainerDiff:
         return self._diff_update_and_compare('uts', before, after)
 
     def diffparam_volume(self):
+        def clean_volume(x):
+            '''Remove trailing and double slashes from volumes.'''
+            return x.replace("//", "/").rstrip("/")
+
         before = self.info['mounts']
         before_local_vols = []
         if before:
@@ -1757,7 +1761,9 @@ class PodmanContainerDiff:
             before = [":".join(v) for v in volumes]
             before_local_vols = [":".join(v) for v in local_vols]
         if self.params['volume'] is not None:
-            after = [":".join(v.split(":")[:2]) for v in self.params['volume']]
+            after = [":".join(
+                [clean_volume(i) for i in v.split(":")[:2]]
+            ) for v in self.params['volume']]
         else:
             after = []
         if before_local_vols:

--- a/tests/integration/targets/podman_container_idempotency/tasks/idem_volumes.yml
+++ b/tests/integration/targets/podman_container_idempotency/tasks/idem_volumes.yml
@@ -60,7 +60,7 @@
     name: idempotency
     state: present
     volumes:
-      - /opt:/somedir
+      - /opt/://somedir
     command: 1h
   register: test5
 
@@ -142,8 +142,8 @@
     state: present
     command: 1h
     volumes:
-      - "/opt:/anotherdir"
-      - "local_volume1:/data"
+      - "/opt//:/anotherdir"
+      - "local_volume1:/data/"
   register: test11
 
 - name: check test11


### PR DESCRIPTION
In case of trailing slash or double slashes, the Podman strips it
automatically. Prepare input data accordingly, so we can compare
with Podman inspected one.
Fix #77 