### PR TITLE
doc: _podman() cmd value can be a list

### DIFF
--- a/plugins/connection/podman.py
+++ b/plugins/connection/podman.py
@@ -95,7 +95,7 @@ class Connection(ConnectionBase):
         """
         run podman executable
 
-        :param cmd: podman's command to execute (str)
+        :param cmd: podman's command to execute (str or list)
         :param cmd_args: list of arguments to pass to the command (list of str/bytes)
         :param in_data: data passed to podman's stdin
         :return: return code, stdout, stderr


### PR DESCRIPTION
Commit cc8d4bb4510bcc79537ed3fa591fb9cace576ae9 changed `_podman()` to accept a string or a list for the "cmd" parameter. Update the docstring for this parameter to reflect this.