### PR TITLE
Fix init: option it's boolean not string

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -343,7 +343,7 @@ options:
     description:
       - Run an init inside the container that forwards signals and reaps
         processes. The default is false.
-    type: boolean
+    type: bool
   init_path:
     description:
       - Path to the container-init binary.

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -342,8 +342,8 @@ options:
   init:
     description:
       - Run an init inside the container that forwards signals and reaps
-        processes.
-    type: str
+        processes. The default is false.
+    type: boolean
   init_path:
     description:
       - Path to the container-init binary.
@@ -1067,7 +1067,9 @@ class PodmanModuleParams:
         return c + ['--image-volume', self.params['image_volume']]
 
     def addparam_init(self, c):
-        return c + ['--init', self.params['init']]
+        if self.params['init']:
+            c += ['--init']
+        return c
 
     def addparam_init_path(self, c):
         return c + ['--init-path', self.params['init_path']]


### PR DESCRIPTION
If init: true/yes is set it passed as string argument and produces error.
Default init path is predefined as /dev/init and automically injected from catatonit package https://github.com/openSUSE/catatonit
Custom can be set with --init-path=