### PR TITLE
Check if dnsname plugin installed for CNI

### DIFF
--- a/plugins/modules/podman_network.py
+++ b/plugins/modules/podman_network.py
@@ -143,6 +143,7 @@ network:
 # noqa: F402
 import json  # noqa: F402
 from distutils.version import LooseVersion  # noqa: F402
+import os  # noqa: F402
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: F402
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
@@ -271,8 +272,21 @@ class PodmanNetworkDiff:
         return False
 
     def diffparam_disable_dns(self):
-        before = not bool([k for k in self.info['plugins'] if 'domainname' in k])
+        dns_installed = False
+        for f in [
+            '/usr/libexec/cni/dnsname',
+            '/usr/lib/cni/dnsname',
+            '/opt/cni/bin/dnsname',
+            '/opt/bridge/bin/dnsname'
+        ]:
+            if os.path.exists(f):
+                dns_installed = True
+        before = not bool(
+            [k for k in self.info['plugins'] if 'domainname' in k])
         after = self.params['disable_dns']
+        # If dnsname plugin is not installed, default is disable_dns=True
+        if not dns_installed and self.module.params['disable_dns'] is None:
+            after = True
         return self._diff_update_and_compare('disable_dns', before, after)
 
     def diffparam_driver(self):

--- a/tests/integration/targets/podman_network/tasks/main.yml
+++ b/tests/integration/targets/podman_network/tasks/main.yml
@@ -5,6 +5,23 @@
     - name: Print podman version
       command: podman version
 
+    - name: Check if dnsname plugin is installed
+      block:
+
+        - name: Check if plugin is installed
+          stat:
+            path: "{{ item }}"
+          loop:
+            - /usr/libexec/cni/dnsname
+            - /usr/lib/cni/dnsname
+            - /opt/cni/bin/dnsname
+            - /opt/bridge/bin/dnsname
+          register: plugin_results
+
+        - name: Set plugin fact
+          set_fact:
+            dns_plugin: "{{ true in plugin_results.results|map(attribute='stat.exists') }}"
+
     - name: Generate random value for network name
       set_fact:
         network_name: "{{ 'ansible-test-podman-%0x' % ((2**32) | random) }}"
@@ -63,7 +80,9 @@
     - name: Check info
       assert:
         that:
-          - info3 is changed
+          - >-
+            info3 is changed and dns_plugin|bool or
+            info3 is not changed and not dns_plugin|bool
 
     - name: Create network with disable DNS again
       containers.podman.podman_network:
@@ -86,7 +105,9 @@
     - name: Check info
       assert:
         that:
-          - info5 is changed
+          - >-
+            info5 is changed and dns_plugin|bool or
+            info5 is not changed and not dns_plugin|bool
 
     - name: Create network with custom gateway
       containers.podman.podman_network:


### PR DESCRIPTION
If dnsname plugins is not in specified set of paths, it's not
installed. If it's not installed, then the default values of
disable-dns will be True (as dns is disabled).
Fix #112 