### PR TITLE
Fix signals case for podman_container

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -1715,10 +1715,10 @@ class PodmanContainerDiff:
         }
         before = str(self.info['config']['stopsignal'])
         if not before.isdigit():
-            before = signals[before]
+            before = signals[before.lower()]
         after = str(self.params['stop_signal'])
         if not after.isdigit():
-            after = signals[after]
+            after = signals[after.lower()]
         return self._diff_update_and_compare('stop_signal', before, after)
 
     def diffparam_tty(self):

--- a/tests/integration/targets/podman_container_idempotency/files/Dockerfile
+++ b/tests/integration/targets/podman_container_idempotency/files/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 80
 EXPOSE 8080/tcp
 VOLUME ["/data", "/data2"]
 USER user
-STOPSIGNAL 9
+STOPSIGNAL SIGKILL
 
 # problem with OS w/o systemd
 # HEALTHCHECK --interval=5m --timeout=3s \


### PR DESCRIPTION
In #113 we made a change to lowercase only keys, so signals should
be now upper case.

Related to #125.