### PR TITLE
Add podman logout module

### DIFF
--- a/.github/workflows/podman_logout.yml
+++ b/.github/workflows/podman_logout.yml
@@ -1,0 +1,110 @@
+name: Podman logout
+
+on:
+  push:
+    paths:
+      - '.github/workflows/podman_logout.yml'
+      - 'ci/*.yml'
+      - 'ci/run_containers_tests.sh'
+      - 'ci/playbooks/containers/podman_logout.yml'
+      - 'plugins/modules/podman_logout.py'
+      - 'tests/integration/targets/podman_logout/**'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '.github/workflows/podman_logout.yml'
+      - 'ci/*.yml'
+      - 'ci/run_containers_tests.sh'
+      - 'ci/playbooks/containers/podman_logout.yml'
+      - 'plugins/modules/podman_logout.py'
+      - 'tests/integration/targets/podman_logout/**'
+  schedule:
+    - cron: 4 0 * * *  # Run daily at 0:03 UTC
+
+jobs:
+
+  test_podman_logout:
+    name: Podman logout ${{ matrix.ansible-version }}-${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible-version:
+          - ansible<2.10
+          # - git+https://github.com/ansible/ansible.git@stable-2.10
+        os:
+          - ubuntu-latest
+        python-version:
+          - 3.7
+        include:
+          - os: ubuntu-20.04
+            ansible-version: git+https://github.com/ansible/ansible.git@devel
+            python-version: 3.7
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip and display Python and PIP versions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python*-wheel python*-yaml
+          python -m pip install --upgrade pip
+          python -V
+          pip --version
+
+      - name: Set up pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ github.ref }}-units-VMs
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Install Ansible ${{ matrix.ansible-version }}
+        run: python3 -m pip install --user --force-reinstall --upgrade '${{ matrix.ansible-version }}'
+
+      - name: Build and install the collection tarball
+        run: |
+          rm -rf /tmp/just_new_collection
+          ~/.local/bin/ansible-galaxy collection build --output-path /tmp/just_new_collection --force
+          ~/.local/bin/ansible-galaxy collection install -vvv --force /tmp/just_new_collection/*.tar.gz
+
+      - name: Run collection tests for podman logout
+        run: |
+          export PATH=~/.local/bin:$PATH
+
+          echo "Run ansible version"
+          command -v ansible
+          ansible --version
+
+          if [[ '${{ matrix.ansible-version }}'  == 'git+https://github.com/ansible/ansible.git@devel' ]]; then
+            export ANSIBLE_CONFIG=$(pwd)/ci/ansible-dev.cfg
+          elif [[ '${{ matrix.ansible-version }}'  == 'ansible<2.10' ]]; then
+            export ANSIBLE_CONFIG=$(pwd)/ci/ansible-2.9.cfg
+          fi
+
+          echo $ANSIBLE_CONFIG
+          command -v ansible-playbook
+          pip --version
+          python --version
+          ansible-playbook --version
+
+          ansible-playbook -vv ci/playbooks/pre.yml \
+          -e host=localhost \
+          -i localhost, \
+          -e ansible_connection=local \
+          -e setup_python=false
+
+          TEST2RUN=podman_logout ./ci/run_containers_tests.sh
+        shell: bash

--- a/ci/playbooks/containers/podman_logout.yml
+++ b/ci/playbooks/containers/podman_logout.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+    - include_role:
+        name: podman_logout
+      vars:
+        ansible_python_interpreter: "{{ _ansible_python_interpreter }}"

--- a/plugins/modules/podman_logout.py
+++ b/plugins/modules/podman_logout.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: podman_logout
+author:
+  - "Clemens Lange (@clelange)"
+short_description: Log out of a container registry using podman
+notes: []
+description:
+  - Log out of a container registry server using the podman logout command
+    by deleting the cached credentials stored in the `auth.json` file.
+    If the registry is not specified, the first registry under
+    `[registries.search]` from `registries.conf `will be used. The path of
+    the authentication file can be overridden by the user by setting the
+    `authfile` flag. The default path used is
+    `${XDG_RUNTIME_DIR}/containers/auth.json`.
+    All the cached credentials can be removed by setting the `all` flag.
+requirements:
+  - "Podman installed on host"
+options:
+  registry:
+    description:
+      - Registry server. If the registry is not specified,
+        the first registry under `[registries.search]` from
+        `registries.conf` will be used.
+    type: str
+  authfile:
+    description:
+      - Path of the authentication file. Default is
+        ``${XDG_RUNTIME_DIR}/containers/auth.json``
+        You can also override the default path of the authentication
+        file by setting the ``REGISTRY_AUTH_FILE`` environment
+        variable. ``export REGISTRY_AUTH_FILE=path``
+    type: path
+  all:
+    description:
+      - Remove the cached credentials for all registries in the auth file
+    type: bool
+  executable:
+    description:
+      - Path to C(podman) executable if it is not in the C($PATH) on the
+        machine running C(podman)
+    default: 'podman'
+    type: str
+'''
+
+EXAMPLES = r"""
+- name: Log out of default registry
+  podman_logout:
+
+- name: Log out of quay.io
+  podman_logout:
+    registry: quay.io
+
+- name: Log out of all registries in auth file
+  podman_logout:
+    all: yes
+
+- name: Log out of all registries in specified auth file
+  podman_logout:
+    authfile: $HOME/.docker/config.json
+    all: yes
+"""
+# noqa: F402
+
+import json  # noqa: F402
+from ansible.module_utils.basic import AnsibleModule
+
+
+def logout(module, executable, registry, authfile, all_registries):
+    command = [executable, 'logout']
+    changed = False
+    if authfile:
+        command.extend(['--authfile', authfile])
+    if registry:
+        command.append(registry)
+    if all_registries:
+        command.append("--all")
+    rc, out, err = module.run_command(command)
+    if rc != 0:
+        if 'Error: not logged into' not in err:
+            module.fail_json(msg="Unable to gather info for %s: %s" % (registry, err))
+    else:
+        # If the command is successful, we managed to log out
+        # Mind: This also applied if --all flag is used, while in this case
+        # there is no check whether one has been logged into any registry
+        changed = True
+    return changed, out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            executable=dict(type='str', default='podman'),
+            registry=dict(type='str'),
+            authfile=dict(type='path'),
+            all=dict(type='bool'),
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=(
+            ['registry', 'all'],
+        ),
+    )
+
+    registry = module.params['registry']
+    authfile = module.params['authfile']
+    all_registries = module.params['all']
+    executable = module.get_bin_path(module.params['executable'], required=True)
+
+    changed, out, err = logout(module, executable, registry, authfile, all_registries)
+
+    results = {
+        "changed": changed,
+        "stdout": out,
+        "stderr": err,
+    }
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/podman_logout.py
+++ b/plugins/modules/podman_logout.py
@@ -82,7 +82,7 @@ def logout(module, executable, registry, authfile, all_registries):
         command.append("--all")
     rc, out, err = module.run_command(command)
     if rc != 0:
-        if 'Error: not logged into' not in err:
+        if 'Error: Not logged into' not in err:
             module.fail_json(msg="Unable to gather info for %s: %s" % (registry, err))
     else:
         # If the command is successful, we managed to log out

--- a/tests/integration/targets/podman_logout/tasks/main.yml
+++ b/tests/integration/targets/podman_logout/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: Test podman_logout
+  block:
+
+    - name: Print podman version
+      command: podman version
+
+    - name: Log out of non-existing registry
+      containers.podman.podman_logout:
+      register: non_existing_registry
+
+    - name: Check results
+      assert:
+        that:
+          - "'changed' in non_existing_registry"
+          - "non_existing_registry.changed == False"
+
+    - name: Log out of all registries
+      containers.podman.podman_logout:
+        all: yes
+      register: all_registries
+
+    - name: Check results
+      assert:
+        that:
+          - "'changed' in all_registries"
+          - "all_registries.changed == True"

--- a/tests/integration/targets/podman_logout/tasks/main.yml
+++ b/tests/integration/targets/podman_logout/tasks/main.yml
@@ -5,7 +5,7 @@
       command: podman version
 
     - name: Log out with invalid executable
-      podman_logout:
+      containers.podman.podman_logout:
         executable: podman_invalid
       register: invalid_executable
       ignore_errors: yes
@@ -16,7 +16,7 @@
           - invalid_executable is failed
 
     - name: Log out of non-existing registry
-      podman_logout:
+      containers.podman.podman_logout:
       register: non_existing_registry
 
     - name: Check results
@@ -26,7 +26,7 @@
           - "non_existing_registry.changed == False"
 
     - name: Log out with invalid authfile
-      podman_logout:
+      containers.podman.podman_logout:
         authfile: authfile_invalid.json
       register: invalid_authfile
       ignore_errors: yes
@@ -37,7 +37,7 @@
           - invalid_authfile is failed
 
     - name: Log out of all registries
-      podman_logout:
+      containers.podman.podman_logout:
         all: yes
       register: all_registries
 

--- a/tests/integration/targets/podman_logout/tasks/main.yml
+++ b/tests/integration/targets/podman_logout/tasks/main.yml
@@ -16,7 +16,7 @@
           - invalid_executable is failed
 
     - name: Log out of non-existing registry
-      containers.podman.podman_logout:
+      podman_logout:
       register: non_existing_registry
 
     - name: Check results
@@ -37,7 +37,7 @@
           - invalid_authfile is failed
 
     - name: Log out of all registries
-      containers.podman.podman_logout:
+      podman_logout:
         all: yes
       register: all_registries
 

--- a/tests/integration/targets/podman_logout/tasks/main.yml
+++ b/tests/integration/targets/podman_logout/tasks/main.yml
@@ -4,6 +4,17 @@
     - name: Print podman version
       command: podman version
 
+    - name: Log out with invalid executable
+      podman_logout:
+        executable: podman_invalid
+      register: invalid_executable
+      ignore_errors: yes
+
+    - name: Check invalid executable results
+      assert:
+        that:
+          - invalid_executable is failed
+
     - name: Log out of non-existing registry
       containers.podman.podman_logout:
       register: non_existing_registry
@@ -13,6 +24,17 @@
         that:
           - "'changed' in non_existing_registry"
           - "non_existing_registry.changed == False"
+
+    - name: Log out with invalid authfile
+      podman_logout:
+        authfile: authfile_invalid.json
+      register: invalid_authfile
+      ignore_errors: yes
+
+    - name: Check invalid authfile results
+      assert:
+        that:
+          - invalid_authfile is failed
 
     - name: Log out of all registries
       containers.podman.podman_logout:


### PR DESCRIPTION
This adds a module to log out of a specified container registry or all registries wrapping the `podman logout` command with all its options.

I've also added a few tests, which are possible without an actual log in. The GitHub Actions workflow as well as the playbook are adjusted copies of the podman_volume_info equivalent.

Please let me know if you have any suggestions. Once login and login_info modules are in place, a combination of them can be tested together (if secrets are added to this repository).

Labelling this PR for hacktoberfest would be appreciated.

Addresses #94 