### PR TITLE
Add 'created' state for podman_container

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -51,6 +51,10 @@ options:
         a matching container to be stopped and restarted.
       - I(stopped) - Asserts that the container is first I(present), and then
         if the container is running moves it to a stopped state.
+      - I(created) - Asserts that the container exists with given configuration.
+        If container doesn't exist, the module creates it and leaves it in
+        'created' state. If configuration doesn't match or 'recreate' option is
+        set, the container will be recreated
     type: str
     default: started
     choices:
@@ -58,6 +62,7 @@ options:
       - present
       - stopped
       - started
+      - created
   image:
     description:
       - Repository path (or image name) and tag used to create the container.

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -165,7 +165,7 @@
         fail_msg: Deleting stopped container test failed!
         success_msg: Deleting stopped container test passed!
 
-    - name: Create container, but don't run
+    - name: Create container in 'stopped' state
       containers.podman.podman_container:
         name: container
         image: alpine:3.7
@@ -183,6 +183,48 @@
           - "'created container' in created.actions"
         fail_msg: "Creating stopped container test failed!"
         success_msg: "Creating stopped container test passed!"
+
+    - name: Delete created container
+      containers.podman.podman_container:
+        name: container
+        state: absent
+
+    - name: Create container in 'created' state
+      containers.podman.podman_container:
+        name: container
+        image: alpine:3.7
+        state: created
+        command: sleep 1d
+      register: created
+
+    - name: Check output is correct
+      assert:
+        that:
+          - created is changed
+          - created.container is defined
+          - created.container != {}
+          - not created.container['State']['Running']
+          - "'created container' in created.actions"
+        fail_msg: "Creating stopped container test failed!"
+        success_msg: "Creating stopped container test passed!"
+
+    - name: Force container recreate
+      containers.podman.podman_container:
+        name: container
+        image: alpine
+        state: created
+        command: sleep 1d
+        recreate: true
+      register: recreated
+
+    - name: Check output is correct
+      assert:
+        that:
+          - recreated is changed
+          - recreated.container is defined
+          - not recreated.container['State']['Running']
+          - "'recreated container' in recreated.actions"
+        fail_msg: Force recreate test failed!
 
     - name: Delete created container
       containers.podman.podman_container:

--- a/tests/integration/targets/podman_containers/tasks/main.yml
+++ b/tests/integration/targets/podman_containers/tasks/main.yml
@@ -244,7 +244,7 @@
             command: sleep 1d
           - name: container1
             image: alpine:3.7
-            state: stopped
+            state: created
             command: sleep 1d
       register: created
 
@@ -257,7 +257,7 @@
             command: sleep 1d
           - name: container1
             image: alpine:3.7
-            state: stopped
+            state: created
             command: sleep 1d
       register: created_again
 


### PR DESCRIPTION
Add state 'created' which will ensure container exists in current
configuration. It can either run or not.
Fix #165 