### PR TITLE
Restart container in a simple manner

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1410,6 +1410,17 @@ class PodmanManager:
 
     def make_started(self):
         """Run actions if desired state is 'started'."""
+        if self.container.exists and self.restart:
+            if self.container.running:
+                self.container.restart()
+                self.results['actions'].append('restarted %s' %
+                                               self.container.name)
+            else:
+                self.container.start()
+                self.results['actions'].append('started %s' %
+                                               self.container.name)
+            self.update_container_result()
+            return
         if self.container.running and \
                 (self.container.different or self.recreate):
             self.container.recreate_run()

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -908,8 +908,9 @@ def main():
     )
 
     # work on input vars
-    if module.params['state'] in ['started', 'present'] and \
-            not module.params['image']:
+    if (module.params['state'] in ['started', 'present', 'created']
+            and not module.params['force_restart']
+            and not module.params['image']):
         module.fail_json(msg="State '%s' required image to be configured!" %
                              module.params['state'])
 

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -226,6 +226,36 @@
           - "'recreated container' in recreated.actions"
         fail_msg: Force recreate test failed!
 
+    - name: Restart container
+      containers.podman.podman_container:
+        name: container
+        restart: true
+      register: restarted
+
+    - name: Check output is correct
+      assert:
+        that:
+          - restarted is changed
+          - restarted.container is defined
+          - restarted.container['State']['Running']
+          - "'started container' in restarted.actions"
+        fail_msg: Restart container test failed!
+
+    - name: Restart running container
+      containers.podman.podman_container:
+        name: container
+        restart: true
+      register: restarted
+
+    - name: Check output is correct
+      assert:
+        that:
+          - restarted is changed
+          - restarted.container is defined
+          - restarted.container['State']['Running']
+          - "'restarted container' in restarted.actions"
+        fail_msg: Restart running container test failed!
+
     - name: Delete created container
       containers.podman.podman_container:
         name: container


### PR DESCRIPTION
Don't require an image when restarting container, only the
container name.
Fix #161 