### PR TITLE
podman_container_lib: fix command param idempotency

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import json  # noqa: F402
+import shlex  # noqa: F402
 from distutils.version import LooseVersion  # noqa: F402
 
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
@@ -713,9 +714,7 @@ class PodmanContainerDiff:
             before = self.info['config']['cmd']
             after = self.params['command']
             if isinstance(after, str):
-                after = [i.lower() for i in after.split()]
-            elif isinstance(after, list):
-                after = [i.lower() for i in after]
+                after = shlex.split(after)
             return self._diff_update_and_compare('command', before, after)
         return False
 


### PR DESCRIPTION
Preserve case sensitivity in the command param's idempotency check by:
- using shlex to split command line strings (`shlex.split`:"Split the string s using shell-like syntax.")
- removing the use of `lower()` in both cases of string or list

fixes #173 