### PR TITLE
Fix 'cap_add' and 'cap_drop' idempotency

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -670,21 +670,27 @@ class PodmanContainerDiff:
 
     def diffparam_cap_add(self):
         before = self.info['effectivecaps'] or []
+        before = [i.lower() for i in before]
         after = []
         if self.module_params['cap_add'] is not None:
-            after += ["cap_" + i.lower()
-                      for i in self.module_params['cap_add']]
+            for cap in self.module_params['cap_add']:
+                cap = cap.lower()
+                cap = cap if cap.startswith('cap_') else 'cap_' + cap
+                after.append(cap)
         after += before
         before, after = sorted(list(set(before))), sorted(list(set(after)))
         return self._diff_update_and_compare('cap_add', before, after)
 
     def diffparam_cap_drop(self):
         before = self.info['effectivecaps'] or []
+        before = [i.lower() for i in before]
         after = before[:]
         if self.module_params['cap_drop'] is not None:
-            for c in ["cap_" + i.lower() for i in self.module_params['cap_drop']]:
-                if c in after:
-                    after.remove(c)
+            for cap in self.module_params['cap_drop']:
+                cap = cap.lower()
+                cap = cap if cap.startswith('cap_') else 'cap_' + cap
+                if cap in after:
+                    after.remove(cap)
         before, after = sorted(list(set(before))), sorted(list(set(after)))
         return self._diff_update_and_compare('cap_drop', before, after)
 


### PR DESCRIPTION
This change fixes containers always being rebuilt when the `cap_add` or `cap_drop` options are used. For example:

```yaml
containers.podman.podman_container:
  cap_add:
    - "NET_BIND_SERVICE"
    - "CAP_AUDIT_WRITE"
  ...
```

Consecutive runs produce the following diff:

```
--- before
+++ after
@@ -1 +1 @@
-cap_add - ['CAP_AUDIT_WRITE', 'CAP_NET_BIND_SERVICE']
+cap_add - ['CAP_AUDIT_WRITE', 'CAP_NET_BIND_SERVICE', 'cap_cap_audit_write', 'cap_net_bind_service']
```

Lower-casing and checking if the option already contains the `cap_` prefix fixes the issue (for me).
