### PR TITLE
Resolves Issue #182 - log_level not idempotent on CentOS 8

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -576,7 +576,7 @@ class PodmanDefaults:
             "ipc": "",
             "kernelmemory": "0",
             "log_driver": "k8s-file",
-            "log_level": "error",
+            "log_level": None,
             "memory": "0",
             "memory_swap": "0",
             "memory_reservation": "0",
@@ -886,7 +886,7 @@ class PodmanContainerDiff:
         if '--log-level' in createcom:
             before = createcom[createcom.index('--log-level') + 1].lower()
         else:
-            before = self.params['log_level']
+            before = None
         after = self.params['log_level']
         return self._diff_update_and_compare('log_level', before, after)
 

--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -882,9 +882,9 @@ class PodmanContainerDiff:
         return self._diff_update_and_compare('log_driver', before, after)
 
     def diffparam_log_level(self):
-        excom = self.info['exitcommand']
-        if '--log-level' in excom:
-            before = excom[excom.index('--log-level') + 1].lower()
+        createcom = self.info['config']['createcommand']
+        if '--log-level' in createcom:
+            before = createcom[createcom.index('--log-level') + 1].lower()
         else:
             before = self.params['log_level']
         after = self.params['log_level']


### PR DESCRIPTION
This PR fixes the location the module looks in to determine the containers log-level setting when it was created. Prior to this fix it was checking the `exitcommand`, this is post container exit clean up commands for podman. Changed the function to look instead at `['config']['createcommand']` for the `log_level` setting to diff against. Ansible runs now execute without recreating the container every run.