### PR TITLE
Add sigrtmin+3 signal (required for systemd containers)

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1111,7 +1111,8 @@ class PodmanContainerDiff:
             "sigwinch": "28",
             "sigio": "29",
             "sigpwr": "30",
-            "sigsys": "31"
+            "sigsys": "31",
+            "sigrtmin+3": "37"
         }
         before = str(self.info['config']['stopsignal'])
         if not before.isdigit():


### PR DESCRIPTION
Fixes the following error when using this module with a systemd-enabled container:

`An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'sigrtmin+3'
failed: [XXX] (item=9) => {"ansible_loop_var": "item", "changed": false, "item": 9, "module_stderr": "Shared connection to XXX closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1615576591.0259745-488102-124656477496642/AnsiballZ_podman_container.py\", line 102, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1615576591.0259745-488102-124656477496642/AnsiballZ_podman_container.py\", line 94, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1615576591.0259745-488102-124656477496642/AnsiballZ_podman_container.py\", line 40, in invoke_module\r\n    runpy.run_module(mod_name='ansible_collections.containers.podman.plugins.modules.podman_container', init_globals=None, run_name='__main__', alter_sys=True)\r\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\r\n    mod_name, mod_spec, pkg_name, script_name)\r\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/modules/podman_container.py\", line 924, in <module>\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/modules/podman_container.py\", line 919, in main\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/module_utils/podman/podman_container_lib.py\", line 1567, in execute\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/module_utils/podman/podman_container_lib.py\", line 1475, in make_started\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/module_utils/podman/podman_container_lib.py\", line 1290, in different\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/module_utils/podman/podman_container_lib.py\", line 1217, in is_different\r\n  File \"/tmp/ansible_containers.podman.podman_container_payload_05eeiqwp/ansible_containers.podman.podman_container_payload.zip/ansible_collections/containers/podman/plugins/module_utils/podman/podman_container_lib.py\", line 1121, in diffparam_stop_signal\r\nKeyError: 'sigrtmin+3'\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}`