### PR TITLE
Stop pods without recreating them

### DIFF
--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -721,14 +721,14 @@ class PodmanPodManager:
 
     def make_stopped(self):
         """Run actions if desired state is 'stopped'."""
-        changed = self._create_or_recreate_pod()
-        if changed or self.pod.stopped:
-            self.update_pod_result(changed=changed)
-            return
-        elif self.pod.running:
+        if not self.pod.exists:
+            self.module.fail_json("Pod %s doesn't exist!" % self.pod.name)
+        if self.pod.running:
             self.pod.stop()
             self.results['actions'].append('stopped %s' % self.pod.name)
             self.update_pod_result()
+        elif self.pod.stopped:
+            self.update_pod_result(changed=False)
 
     def make_restarted(self):
         """Run actions if desired state is 'restarted'."""

--- a/tests/integration/targets/podman_pod/tasks/main.yml
+++ b/tests/integration/targets/podman_pod/tasks/main.yml
@@ -110,6 +110,18 @@
              (pod5_info.pod['State']['status'] is not defined and
              pod5_info.pod['State'] != 'Running')
 
+    - name: Stop non-existing pod
+      containers.podman.podman_pod:
+        name: pod-notexist
+        state: stopped
+      register: pod5a_info
+      ignore_errors: true
+
+    - name: Check info
+      assert:
+        that:
+          - pod5a_info is failed
+
     - name: Kill pod
       containers.podman.podman_pod:
         name: pod1
@@ -177,6 +189,20 @@
       assert:
         that:
           - pod122_info is changed
+
+    - name: Stop pod with additional config
+      containers.podman.podman_pod:
+        name: pod1
+        state: stopped
+        ports:
+          - 9484:9483
+      register: pod123_info
+
+    - name: Check info
+      assert:
+        that:
+          - pod123_info is changed
+          - '"podman pod rm -f pod1" not in pod123_info.podman_actions'
 
     - name: Start pod with ports
       containers.podman.podman_pod:


### PR DESCRIPTION
Stop pod without recreating if its definition isn't the same as
before.
Fix #215