### PR TITLE
Fix uppercase labels idempotency issue

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -873,7 +873,7 @@ class PodmanContainerDiff:
         after = self.image_info.get('labels') or {}
         if self.params['label']:
             after.update({
-                str(k).lower(): str(v).lower()
+                str(k).lower(): str(v)
                 for k, v in self.params['label'].items()
             })
         return self._diff_update_and_compare('label', before, after)

--- a/tests/integration/targets/podman_container_idempotency/tasks/idem_labels.yml
+++ b/tests/integration/targets/podman_container_idempotency/tasks/idem_labels.yml
@@ -51,7 +51,9 @@
     state: present
     label:
       haha: kukuku
-      llala: wiwiwiw
+      LLALA: WIWIWIW
+      OEIWIOP: eufslsa
+      ieui4: KDJSL4D
     command: 1h
   register: test4
 
@@ -65,7 +67,9 @@
     state: present
     label:
       haha: kukuku
-      llala: wiwiwiw
+      LLALA: WIWIWIW
+      OEIWIOP: eufslsa
+      ieui4: KDJSL4D
     command: 1h
   register: test5
 


### PR DESCRIPTION
When we lower cases for all keys, but leave it original case for
all values, we need to do the same with input labels.
Add test.
Fix #227