### PR TITLE
Fix multi-containers options

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -128,6 +128,50 @@ ARGUMENTS_SPEC_CONTAINER = dict(
 )
 
 
+def init_options():
+    default = {}
+    opts = ARGUMENTS_SPEC_CONTAINER
+    for k, v in opts.items():
+        if 'default' in v:
+            default[k] = v['default']
+        else:
+            default[k] = None
+    return default
+
+
+def update_options(opts_dict, container):
+    def to_bool(x):
+        return str(x).lower() not in ['no', 'false']
+
+    aliases = {}
+    for k, v in ARGUMENTS_SPEC_CONTAINER.items():
+        if 'aliases' in v:
+            for alias in v['aliases']:
+                aliases[alias] = k
+    for k in list(container):
+        if k in aliases:
+            key = aliases[k]
+            container[key] = container.pop(k)
+        else:
+            key = k
+        if ARGUMENTS_SPEC_CONTAINER[key]['type'] == 'list' and not isinstance(container[key], list):
+            opts_dict[key] = [container[key]]
+        elif ARGUMENTS_SPEC_CONTAINER[key]['type'] == 'bool' and not isinstance(container[key], bool):
+            opts_dict[key] = to_bool(container[key])
+        elif ARGUMENTS_SPEC_CONTAINER[key]['type'] == 'int' and not isinstance(container[key], int):
+            opts_dict[key] = int(container[key])
+        else:
+            opts_dict[key] = container[key]
+
+    return opts_dict
+
+
+def set_container_opts(input_vars):
+    default_options_templ = init_options()
+    options_dict = update_options(default_options_templ, input_vars)
+    return options_dict
+
+
 class PodmanModuleParams:
     """Creates list of arguments for podman CLI command.
 

--- a/plugins/modules/podman_containers.py
+++ b/plugins/modules/podman_containers.py
@@ -49,33 +49,7 @@ from copy import deepcopy  # noqa: F402
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: F402
 from ..module_utils.podman.podman_container_lib import PodmanManager  # noqa: F402
-from ..module_utils.podman.podman_container_lib import ARGUMENTS_SPEC_CONTAINER  # noqa: F402
-
-
-def init_options():
-    default = {}
-    opts = ARGUMENTS_SPEC_CONTAINER
-    for k, v in opts.items():
-        if 'default' in v:
-            default[k] = v['default']
-        else:
-            default[k] = None
-    return default
-
-
-def update_options(opts_dict, container):
-    aliases = {}
-    for k, v in ARGUMENTS_SPEC_CONTAINER.items():
-        if 'aliases' in v:
-            for alias in v['aliases']:
-                aliases[alias] = k
-    for k in list(container):
-        if k in aliases:
-            key = aliases[k]
-            opts_dict[key] = container[k]
-            container.pop(k)
-    opts_dict.update(container)
-    return opts_dict
+from ..module_utils.podman.podman_container_lib import set_container_opts  # noqa: F402
 
 
 def combine(results):
@@ -143,10 +117,8 @@ def main():
     # work on input vars
 
     results = []
-    default_options_templ = init_options()
     for container in module.params['containers']:
-        options_dict = deepcopy(default_options_templ)
-        options_dict = update_options(options_dict, container)
+        options_dict = set_container_opts(container)
         options_dict['debug'] = module.params['debug'] or options_dict['debug']
         test_input = check_input_strict(options_dict)
         if test_input:

--- a/tests/integration/targets/podman_containers/tasks/main.yml
+++ b/tests/integration/targets/podman_containers/tasks/main.yml
@@ -640,3 +640,11 @@
       containers.podman.podman_pod:
         name: testidempod
         state: absent
+
+- name: Test containers module for root
+  include_tasks: root-multi.yml
+  vars:
+    ansible_python_interpreter: "/usr/bin/python"
+  args:
+    apply:
+      become: true

--- a/tests/integration/targets/podman_containers/tasks/root-multi.yml
+++ b/tests/integration/targets/podman_containers/tasks/root-multi.yml
@@ -1,0 +1,110 @@
+---
+- name: Test podman rootful pod play
+  block:
+
+    - name: Create networks
+      containers.podman.podman_network:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - testnet1
+        - testnet2
+
+    - name: Create container with parameters
+      register: continfo
+      containers.podman.podman_containers:
+        containers:
+          - name: cont1
+            image: docker.io/alpine:3.7
+            state: started
+            command: sleep 1d
+            debug: true
+            network: testnet1
+            add_hosts:
+              host1: 127.0.0.1
+              host2: 127.0.0.1
+            annotation:
+              this: "annotation_value"
+            dns_servers:
+              - 1.1.1.1
+              - 8.8.4.4
+            dns_search_domains: example.com
+            capabilities:
+              - SYS_TIME
+              - NET_ADMIN
+            ports:
+              - "9000:80"
+              - "9001:8000"
+            workdir: "/bin"
+            env:
+              FOO: bar=1
+              BAR: foo
+              TEST: 1
+              BOOL: false
+            label:
+              somelabel: labelvalue
+              otheralbe: othervalue
+            volumes:
+              - /tmp:/data
+            interactive: true
+          - name: cont2
+            image: docker.io/alpine:3.7
+            state: started
+            command: sleep 1d
+            recreate: true
+            network:
+              - testnet2
+              - testnet1
+            etc_hosts:
+              host1: 127.0.0.1
+              host2: 127.0.0.1
+            annotation:
+              this: "annotation_value"
+            dns_servers:
+              - 1.1.1.1
+              - 8.8.4.4
+            dns_search_domains: example.com
+            capabilities:
+              - SYS_TIME
+              - NET_ADMIN
+            ports:
+              - "9002:80"
+              - "9003:8000"
+            workdir: "/bin"
+            env:
+              FOO: bar=1
+              BAR: foo
+              TEST: 1
+              BOOL: false
+            label:
+              somelabel: labelvalue
+              otheralbe: othervalue
+            volumes:
+              - /tmp:/data
+            interactive: false
+
+    - name: Check multiple root containers
+      assert:
+        that:
+          - continfo.containers[0]['NetworkSettings']['Networks'].keys() | list == ['testnet1']
+          - continfo.containers[1]['NetworkSettings']['Networks'].keys() | list == ['testnet1', 'testnet2'] or
+            continfo.containers[1]['NetworkSettings']['Networks'].keys() | list == ['testnet2', 'testnet1']
+
+  always:
+
+    - name: Delete all containers leftovers from tests
+      containers.podman.podman_container:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - cont1
+        - cont2
+        - cont3
+
+    - name: Delete all networks leftovers from tests
+      containers.podman.podman_network:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - testnet1
+        - testnet2


### PR DESCRIPTION
Options in multiple podman containers module are broken when they're lists or booleans. Ansible creates a list from a single option if it's defined as a list in args. Do the same, and convert option to the required type if need.