### PR TITLE
Fix suboption key in podman_container -> generate_systemd documentation

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -297,7 +297,7 @@ options:
     type: dict
     default: {}
     suboptions:
-      file:
+      path:
         description:
           - Specify a path to the directory where unit files will be generated.
             If it doesn't exist, the directory will be created.

--- a/plugins/modules/podman_pod.py
+++ b/plugins/modules/podman_pod.py
@@ -77,7 +77,7 @@ options:
     type: dict
     default: {}
     suboptions:
-      file:
+      path:
         description:
           - Specify a path to the directory where unit files will be generated.
             If it doesn't exist, the directory will be created.


### PR DESCRIPTION
As of this line https://github.com/containers/ansible-podman-collections/blob/5b3f8a4d3dee5031bd639965539158ce273e9f84/plugins/module_utils/podman/common.py#L66 it should be "path", not "file"