### PR TITLE
Don't add newlines to secrets

### DIFF
--- a/plugins/modules/podman_secret.py
+++ b/plugins/modules/podman_secret.py
@@ -96,7 +96,7 @@ def podman_secret_create(module, executable, name, data, force, skip):
             }
 
     rc, out, err = module.run_command(
-        [executable, 'secret', 'create', name, '-'], data=data)
+        [executable, 'secret', 'create', name, '-'], data=data, binary_data=True)
 
     if rc != 0:
         module.fail_json(msg="Unable to create secret: %s" % err)

--- a/tests/integration/targets/podman_secret/tasks/main.yml
+++ b/tests/integration/targets/podman_secret/tasks/main.yml
@@ -49,7 +49,7 @@
     - name: Check secret data
       assert:
         that:
-          - container.stdout == "super secret content\n"  # cat adds a newline
+          - container.stdout == "super secret content"
 
     - name: Remove secret
       containers.podman.podman_secret:


### PR DESCRIPTION
This solves issue https://github.com/containers/ansible-podman-collections/issues/330 , which describes how podman_secret adds newlines (\n) to secrets.

After having a look at the [source code](https://github.com/containers/ansible-podman-collections/blob/a0377fbd240f39d35c8b833b1f961c61b445fc1b/plugins/modules/podman_secret.py#L99) and the [run_command documentation](https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html#ansible-module-utils), it seems the parameter binary_data of run_command must be `true` to prevent new lines being added to data:

> Kw binary_data - If False, append a newline to the data. Default False