### PR TITLE
Allow to actually pass a list of string for "mounts"

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -91,7 +91,7 @@ ARGUMENTS_SPEC_CONTAINER = dict(
     memory_reservation=dict(type='str'),
     memory_swap=dict(type='str'),
     memory_swappiness=dict(type='int'),
-    mount=dict(type='str'),
+    mount=dict(type='list', elements='str', aliases=['mounts']),
     network=dict(type='list', elements='str', aliases=['net', 'network_mode']),
     network_aliases=dict(type='list', elements='str'),
     no_hosts=dict(type='bool'),
@@ -472,7 +472,10 @@ class PodmanModuleParams:
         return c + ['--memory-swappiness', self.params['memory_swappiness']]
 
     def addparam_mount(self, c):
-        return c + ['--mount', self.params['mount']]
+        for mnt in self.params['mount']:
+            if mnt:
+                c += ['--mount', mnt]
+        return c
 
     def addparam_network(self, c):
         return c + ['--network', ",".join(self.params['network'])]

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -546,7 +546,10 @@ options:
       - Attach a filesystem mount to the container. bind or tmpfs
         For example mount
         "type=bind,source=/path/on/host,destination=/path/in/container"
-    type: str
+    type: list
+    elements: str
+    aliases:
+      - mounts
   network:
     description:
       - Set the Network mode for the container

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -355,6 +355,8 @@
           otheralbe: othervalue
         volumes:
           - /tmp:/data
+        mounts:
+          - type=devpts,destination=/dev/pts
       register: test
 
     - name: Check output is correct
@@ -396,15 +398,19 @@
           - test.container['Config']['Labels']['somelabel'] == "labelvalue"
           - test.container['Config']['Labels']['otheralbe'] == "othervalue"
           # test mounts
+          - test.container['Mounts'][0]['Type'] is defined and test.container['Mounts'][0]['Type'] == 'bind'
+          - test.container['Mounts'][0]['Source'] is defined and test.container['Mounts'][0]['Source'] == 'devpts'
+          - test.container['Mounts'][0]['Destination'] is defined and test.container['Mounts'][0]['Destination'] == '/dev/pts'
+          # test volumes
           - >-
-            (test.container['Mounts'][0]['Destination'] is defined and
+            (test.container['Mounts'][1]['Destination'] is defined and
             '/data' in test.container['Mounts'] | map(attribute='Destination') | list) or
-            (test.container['Mounts'][0]['destination'] is defined and
+            (test.container['Mounts'][1]['destination'] is defined and
             '/data' in test.container['Mounts'] | map(attribute='destination') | list)
           - >-
-            (test.container['Mounts'][0]['Source'] is defined and
+            (test.container['Mounts'][1]['Source'] is defined and
             '/tmp' in test.container['Mounts'] | map(attribute='Source') | list) or
-            (test.container['Mounts'][0]['source'] is defined and
+            (test.container['Mounts'][1]['source'] is defined and
             '/tmp' in test.container['Mounts'] | map(attribute='source') | list)
         fail_msg: Parameters container test failed!
         success_msg: Parameters container test passed!


### PR DESCRIPTION
Like "volume", "mount" can be passed multiple times to the container
creation/run, therefore we want to support a list of string, and a
"mounts" alias.