### PR TITLE
fix check for read-only change of root image

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -104,7 +104,7 @@ ARGUMENTS_SPEC_CONTAINER = dict(
     publish=dict(type='list', elements='str', aliases=[
         'ports', 'published', 'published_ports']),
     publish_all=dict(type='bool'),
-    read_only=dict(type='bool'),
+    read_only=dict(type='bool', default=False),
     read_only_tmpfs=dict(type='bool'),
     recreate=dict(type='bool', default=False),
     requires=dict(type='list', elements='str'),
@@ -1157,6 +1157,11 @@ class PodmanContainerDiff:
                 return self._diff_update_and_compare('publish', '', '')
         before, after = sorted(list(set(before))), sorted(list(set(after)))
         return self._diff_update_and_compare('publish', before, after)
+
+    def diffparam_read_only(self):
+        before = self.info['hostconfig']['readonlyrootfs']
+        after = self.params['read_only']
+        return self._diff_update_and_compare('read_only', before, after)
 
     def diffparam_rm(self):
         before = self.info['hostconfig']['autoremove']

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -637,6 +637,7 @@ options:
     description:
       - Mount the container's root filesystem as read only. Default is false
     type: bool
+    default: False
   read_only_tmpfs:
     description:
       - If container is running in --read-only mode, then mount a read-write


### PR DESCRIPTION
The --read-only option is not checked for changes between runs of
ansible thus the container is not recreated if the user changes
the root image between read-write to read-only.

Default for the read_only variable set to False in line with
documentation and so that later checks are simplified.

This is a fix for bug #383.

Signed-off-by: Andrew <rubiksdot@grue.cc>