### PR TITLE
Fix log_level module parameter

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -976,11 +976,17 @@ class PodmanContainerDiff:
         if '--log-level' in excom:
             before = excom[excom.index('--log-level') + 1].lower()
         else:
-            if self.module.params['log_level'] is not None:
+            before = self.module.params.get(
+                "log_level",
+                self.module_params.get(
+                    "log_level"
+                )
+            )
+            if before is not None:
                 before = ''
             else:
-                before = self.params['log_level']
-        after = self.params['log_level']
+                before = self.params.get("log_level")
+        after = self.params.get("log_level")
         return self._diff_update_and_compare('log_level', before, after)
 
     # Parameter has limited idempotency, unable to guess the default log_path


### PR DESCRIPTION
The `log_level` module parameter is not guaranteed by Ansible and not
something we have a default for within the library. If the `log_level`
parameter is not defined the following error will be raised resulting
in deployment failure [0]. This change adjusts how the `log_level`
parameter is collected so that we can ensure the module isn't failing
unnecessarily.

[0] https://paste.opendev.org/show/b3dJmgeuZKna74RQo5vy/

Signed-off-by: Kevin Carter <kecarter@redhat.com>