### PR TITLE
Fixed handling of log_level module parameter

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -976,7 +976,7 @@ class PodmanContainerDiff:
         if '--log-level' in excom:
             before = excom[excom.index('--log-level') + 1].lower()
         else:
-            if self.module.params['log_level'] is not None:
+            if 'log_level' in self.module_params:
                 before = ''
             else:
                 before = self.params['log_level']


### PR DESCRIPTION
Parameter 'log_level' might not have been defined in module parameters.
Use self.module_params instead of self.module.params because what is
passed to PodmanManager as params might differ from module params, e.g.
in module podman_containers.