### PR TITLE
Remove idempotency for log level

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -966,23 +966,6 @@ class PodmanContainerDiff:
             after = before
         return self._diff_update_and_compare('log_driver', before, after)
 
-    def diffparam_log_level(self):
-        if 'exitcommand' in self.info:
-            excom = self.info.get('exitcommand', [])
-        elif 'createcommand' in self.info['config']:
-            excom = self.info['config'].get('createcommand', [])
-        else:
-            self._diff_update_and_compare('log_level', '', '')
-        if '--log-level' in excom:
-            before = excom[excom.index('--log-level') + 1].lower()
-        else:
-            if self.module.params['log_level'] is not None:
-                before = ''
-            else:
-                before = self.params['log_level']
-        after = self.params['log_level']
-        return self._diff_update_and_compare('log_level', before, after)
-
     # Parameter has limited idempotency, unable to guess the default log_path
     def diffparam_log_opt(self):
         before, after = {}, {}

--- a/tests/integration/targets/podman_container_idempotency/tasks/idem_all.yml
+++ b/tests/integration/targets/podman_container_idempotency/tasks/idem_all.yml
@@ -68,57 +68,6 @@
   assert:
     that: test4 is changed
 
-- name: Run container with log level
-  containers.podman.podman_container:
-    image: "{{ idem_image }}"
-    name: idempotency
-    state: present
-    log_level: debug
-    command: 1h
-  register: test5
-
-- name: Check info with log level
-  assert:
-    that: test5 is changed
-
-- name: Run container with log level again
-  containers.podman.podman_container:
-    image: "{{ idem_image }}"
-    name: idempotency
-    state: present
-    log_level: debug
-    command: 1h
-  register: test6
-
-- name: Check info with log level again
-  assert:
-    that: test6 is not changed
-
-- name: Run container with changed log level
-  containers.podman.podman_container:
-    image: "{{ idem_image }}"
-    name: idempotency
-    state: present
-    log_level: fatal
-    command: 1h
-  register: test7
-
-- name: Check info with changed log level
-  assert:
-    that: test7 is changed
-
-- name: Run container with default log level
-  containers.podman.podman_container:
-    image: "{{ idem_image }}"
-    name: idempotency
-    state: present
-    command: 1h
-  register: test8
-
-- name: Check info with default log level
-  assert:
-    that: test8 is changed
-
 - name: Run container with log opt tag
   containers.podman.podman_container:
     image: "{{ idem_image }}"


### PR DESCRIPTION
Since Podman changes its defaults very often and it's impossible
to track and identify every time what is current log level, let's
remove idempotency for this parameter for now.

Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>