### PR TITLE
fix image change detection on id change

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -921,7 +921,7 @@ class PodmanContainerDiff:
     def diffparam_image(self):
         before_id = self.info['image']
         after_id = self.image_info['id']
-        if before_id == after_id:
+        if before_id != after_id:
             return self._diff_update_and_compare('image', before_id, after_id)
         before = self.info['config']['image']
         after = self.params['image']


### PR DESCRIPTION
If the image id changes than the image changed. As such we should
return signalling that change.

This is a fix for bug #384.

Signed-off-by: Andrew <rubiksdot@grue.cc>