### PR TITLE
Loop over image names when multiple images present in archive

### DIFF
--- a/plugins/modules/podman_load.py
+++ b/plugins/modules/podman_load.py
@@ -155,7 +155,7 @@ def load(module, executable):
     if rc != 0:
         module.fail_json(msg="Image loading failed: %s" % (err))
     image_name_line = [i for i in out.splitlines() if 'Loaded image' in i][0]
-    image_name = image_name_line.split(":", maxsplit=1)[1].strip()
+    image_name = image_name_line.split("Loaded image(s): ")[1].split(',')[0].strip()
     rc, out2, err2 = module.run_command([executable, 'image', 'inspect', image_name])
     if rc != 0:
         module.fail_json(msg="Image %s inspection failed: %s" % (image_name, err2))

--- a/tests/integration/targets/podman_load/tasks/main.yml
+++ b/tests/integration/targets/podman_load/tasks/main.yml
@@ -52,3 +52,31 @@
     that:
       - image.image != {}
       - image.image.NamesHistory.0 == "k8s.gcr.io/pause:latest"
+
+- name: Pull images
+  containers.podman.podman_image:
+    name: '{{ item }}'
+  loop:
+    - k8s.gcr.io/coredns:1.7.0
+    - k8s.gcr.io/echoserver:1.10
+
+- name: Clean up multifile
+  ansible.builtin.file:
+    path: /tmp/multi.tar
+    state: absent
+
+- name: Create multi image file
+  shell: >-
+    podman save k8s.gcr.io/coredns:1.7.0 k8s.gcr.io/echoserver:1.10 -o /tmp/multi.tar
+
+- name: Load image from oci-dir multi image archive
+  containers.podman.podman_load:
+    input: /tmp/multi.tar
+  register: image
+
+- name: Check it's loaded
+  assert:
+    that:
+      - image.image != {}
+      - '"k8s.gcr.io/coredns:1.7.0" in image.image.NamesHistory'
+      - '"k8s.gcr.io/echoserver:1.10" in image.image.NamesHistory'


### PR DESCRIPTION
Fix #411 
Loop over image names when multiple images present in archive
Appropriately appending output

Signed-off-by: Cory Prelerson <cprelerson42@gmail.com>