### PR TITLE
Fix play_kube not working when yaml not installed on target (#415)

### DIFF
--- a/plugins/modules/podman_play.py
+++ b/plugins/modules/podman_play.py
@@ -193,7 +193,7 @@ class PodmanKubeManagement:
                         "No metadata in Kube file!\n%s" % pod)
             else:
                 with open(self.module.params['kube_file']) as text:
-                    re_pod = NAME.search(text)
+                    re_pod = NAME.search(text.read())
                     if re_pod:
                         pod_name = re_pod.group(1)
         if not pod_name:


### PR DESCRIPTION
Was passing a file handle instead of a string.

Closes #415.