### PR TITLE
podman_container.py: Fix typo in the documentation

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -608,7 +608,7 @@ options:
   pod:
     description:
       - Run container in an existing pod.
-        If you want podman to make the pod for you, preference the pod name
+        If you want podman to make the pod for you, prefix the pod name
         with "new:"
     type: str
   privileged:


### PR DESCRIPTION
I believe "prefix" is what was meant here