### PR TITLE
Change imports of distutils to setuptools

### DIFF
--- a/plugins/connection/podman.py
+++ b/plugins/connection/podman.py
@@ -56,7 +56,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_PODMAN_EXECUTABLE
 '''
 
-import distutils.spawn
+import setuptools._distutils.spawn as spawn
 import os
 import shlex
 import shutil
@@ -102,7 +102,7 @@ class Connection(ConnectionBase):
         :return: return code, stdout, stderr
         """
         podman_exec = self.get_option('podman_executable')
-        podman_cmd = distutils.spawn.find_executable(podman_exec)
+        podman_cmd = spawn.find_executable(podman_exec)
         if not podman_cmd:
             raise AnsibleError("%s command not found in PATH" % podman_exec)
         local_cmd = [podman_cmd]

--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 import json  # noqa: F402
 import shlex  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
+from setuptools._distutils.version import LooseVersion  # noqa: F402
 
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import lower_keys

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import json
-from distutils.version import LooseVersion
+from setuptools._distutils.version import LooseVersion
 
 from ansible.module_utils._text import to_bytes, to_native
 

--- a/plugins/modules/podman_network.py
+++ b/plugins/modules/podman_network.py
@@ -161,7 +161,7 @@ network:
 """
 
 import json  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
+from setuptools._distutils.version import LooseVersion  # noqa: F402
 import os  # noqa: F402
 try:
     import ipaddress

--- a/plugins/modules/podman_volume.py
+++ b/plugins/modules/podman_volume.py
@@ -100,7 +100,7 @@ EXAMPLES = '''
 '''
 # noqa: F402
 import json  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
+from setuptools._distutils.version import LooseVersion  # noqa: F402
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: F402
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402


### PR DESCRIPTION
Fix #422
The distutils package is deprecated and slated for removal in Python 3.12