### PR TITLE
Allow specify podman_network options MTU and VLAN separately

### DIFF
--- a/plugins/modules/podman_network.py
+++ b/plugins/modules/podman_network.py
@@ -253,9 +253,10 @@ class PodmanNetworkModuleParams:
 
     def addparam_opt(self, c):
         for opt in self.params['opt'].items():
-            c += ['--opt',
-                  b"=".join([to_bytes(k, errors='surrogate_or_strict')
-                             for k in opt])]
+            if opt[1] is not None:
+                c += ['--opt',
+                      b"=".join([to_bytes(k, errors='surrogate_or_strict')
+                                 for k in opt])]
         return c
 
     def addparam_disable_dns(self, c):

--- a/tests/integration/targets/podman_network/tasks/main.yml
+++ b/tests/integration/targets/podman_network/tasks/main.yml
@@ -217,6 +217,48 @@
         that:
           - info100 is failed
 
+    - name: Create network with opts MTU
+      containers.podman.podman_network:
+        name: "{{ network_name }}"
+        state: present
+        opt:
+          mtu: 1311
+      register: opt1
+
+    - name: Create network with opts VLAN
+      containers.podman.podman_network:
+        name: "{{ network_name }}"
+        state: present
+        opt:
+          vlan: 5555
+      register: opt2
+
+    - name: Create network with opts MTU and VLAN
+      containers.podman.podman_network:
+        name: "{{ network_name }}"
+        state: present
+        opt:
+          mtu: 1311
+          vlan: 5555
+      register: opt3
+
+    - name: Create network with opts MTU and VLAN again
+      containers.podman.podman_network:
+        name: "{{ network_name }}"
+        state: present
+        opt:
+          mtu: 1311
+          vlan: 5555
+      register: opt4
+
+    - name: Check results for network opts
+      assert:
+        that:
+          - opt1 is changed
+          - opt2 is changed
+          - opt3 is changed
+          - opt4 is not changed
+
   always:
 
     - name: Cleanup


### PR DESCRIPTION
Before that it didn't work when only one option set.
Fix #433 