### PR TITLE
Remove distutils as deprecated

### DIFF
--- a/plugins/connection/podman.py
+++ b/plugins/connection/podman.py
@@ -56,12 +56,12 @@ DOCUMENTATION = '''
           - name: ANSIBLE_PODMAN_EXECUTABLE
 '''
 
-import distutils.spawn
 import os
 import shlex
 import shutil
 import subprocess
 
+from ansible.module_utils.common.process import get_bin_path
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, ensure_connect
@@ -103,7 +103,10 @@ class Connection(ConnectionBase):
         :return: return code, stdout, stderr
         """
         podman_exec = self.get_option('podman_executable')
-        podman_cmd = distutils.spawn.find_executable(podman_exec)
+        try:
+            podman_cmd = get_bin_path(podman_exec)
+        except ValueError:
+            raise AnsibleError("%s command not found in PATH" % podman_exec)
         if not podman_cmd:
             raise AnsibleError("%s command not found in PATH" % podman_exec)
         local_cmd = [podman_cmd]

--- a/plugins/module_utils/podman/common.py
+++ b/plugins/module_utils/podman/common.py
@@ -9,6 +9,17 @@ import os
 import shutil
 import signal
 
+from ansible.module_utils.six import raise_from
+try:
+    from ansible.module_utils.compat.version import LooseVersion  # noqa: F401
+except ImportError:
+    try:
+        from distutils.version import LooseVersion  # noqa: F401
+    except ImportError as exc:
+        raise_from(ImportError('To use this plugin or module with ansible-core'
+                               ' < 2.11, you need to use Python < 3.12 with '
+                               'distutils.version present'), exc)
+
 
 def run_podman_command(module, executable='podman', args=None, expected_rc=0, ignore_errors=False):
     if not isinstance(executable, list):

--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1,9 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 import json  # noqa: F402
 import shlex  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
 
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
+from ansible_collections.containers.podman.plugins.module_utils.podman.common import LooseVersion
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import lower_keys
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import generate_systemd
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import normalize_signal

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -1,9 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 import json
-from distutils.version import LooseVersion
 
 from ansible.module_utils._text import to_bytes, to_native
-
+from ansible_collections.containers.podman.plugins.module_utils.podman.common import LooseVersion
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import lower_keys
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import generate_systemd
 

--- a/plugins/modules/podman_network.py
+++ b/plugins/modules/podman_network.py
@@ -161,7 +161,6 @@ network:
 """
 
 import json  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
 import os  # noqa: F402
 try:
     import ipaddress
@@ -171,7 +170,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: F402
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
-
+from ansible_collections.containers.podman.plugins.module_utils.podman.common import LooseVersion
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import lower_keys
 
 

--- a/plugins/modules/podman_volume.py
+++ b/plugins/modules/podman_volume.py
@@ -100,11 +100,10 @@ EXAMPLES = '''
 '''
 # noqa: F402
 import json  # noqa: F402
-from distutils.version import LooseVersion  # noqa: F402
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: F402
 from ansible.module_utils._text import to_bytes, to_native  # noqa: F402
-
+from ansible_collections.containers.podman.plugins.module_utils.podman.common import LooseVersion
 from ansible_collections.containers.podman.plugins.module_utils.podman.common import lower_keys
 
 


### PR DESCRIPTION
Fix #422
The distutils package is deprecated and slated for removal in Python 3.12