### PR TITLE
Change IpcMode default to shareable

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -678,6 +678,8 @@ class PodmanDefaults:
             self.defaults['pid'] = "private"
         if (LooseVersion(self.version) >= LooseVersion('3.0.0')):
             self.defaults['log_level'] = "warning"
+        if (LooseVersion(self.version) >= LooseVersion('4.1.0')):
+            self.defaults['ipc'] = "shareable"
         return self.defaults
 
 


### PR DESCRIPTION
podman 4.1.x has changed the ipc namespace mode default to
shareable[1] that results in containers being restarted.

[1] https://github.com/containers/podman/commit/3987c529f473178c51feb69d5252c7d5c2a8f697

Resolves: rhbz#2101495