### PR TITLE
Fix rerunning playbooks with generate_systemd --new

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1439,14 +1439,16 @@ class PodmanContainer:
         """Recreate the container."""
         if self.running:
             self.stop()
-        self.delete()
+        if not self.info['HostConfig']['AutoRemove']:
+            self.delete()
         self.create()
 
     def recreate_run(self):
         """Recreate and run the container."""
         if self.running:
             self.stop()
-        self.delete()
+        if not self.info['HostConfig']['AutoRemove']:
+            self.delete()
         self.run()
 
 

--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1484,7 +1484,7 @@ class PodmanManager:
         self.restart = self.module_params['force_restart']
         self.recreate = self.module_params['recreate']
 
-        if self.module_params['generate_systemd']['new']:
+        if self.module_params['generate_systemd'].get('new'):
             self.module_params['rm'] = True
 
         self.container = PodmanContainer(

--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1483,6 +1483,10 @@ class PodmanManager:
         self.state = self.module_params['state']
         self.restart = self.module_params['force_restart']
         self.recreate = self.module_params['recreate']
+
+        if self.module_params['generate_systemd']['new']:
+            self.module_params['rm'] = True
+
         self.container = PodmanContainer(
             self.module, self.name, self.module_params)
 


### PR DESCRIPTION
This fixes Issue #345 by making two changes:

1. If `generate_systemd.new` is set then `rm` is automatically set. This is needed because containers started by systemd services generated with the `--new` option always start with --rm. Otherwise ansible will try to restart container on every rerun, as ansible thinks `rm` should be off, while it has been turned on by the systemd service.
I also tried only changing `PodmanContainerDiff` for this, but that runs into the problem that then the container starts without `rm` when started by ansible but with `rm` once it has been restarted using systemd, leading to further problems.

2. Don't try to delete containers with `AutoRemove` set. As the containers are already removed by podman when they are stopped ansible will fail when it tries to remove them. This issue also affects containers with `rm` set manually, even when not using `generate_systemd`.

EDIT: Force-pushed to add sign-offs to commit