### PR TITLE
Add required argument to example

### DIFF
--- a/plugins/modules/podman_play.py
+++ b/plugins/modules/podman_play.py
@@ -119,6 +119,7 @@ EXAMPLES = '''
 - name: Play kube file
   containers.podman.podman_play:
     kube_file: ~/kube.yaml
+    state: started
 
 '''
 import re  # noqa: F402


### PR DESCRIPTION
The `podman_play` example doesn't work because a required argument is missing.