### PR TITLE
Podman generate systemd

### DIFF
--- a/.github/workflows/podman_generate_systemd.yml
+++ b/.github/workflows/podman_generate_systemd.yml
@@ -1,0 +1,99 @@
+name: Podman generate systemd
+
+on:
+  push:
+    paths:
+      - '.github/workflows/podman_generate_systemd.yml'
+      - 'ci/*.yml'
+      - 'ci/run_containers_tests.sh'
+      - 'ci/playbooks/containers/podman_generate_systemd.yml'
+      - 'plugins/modules/podman_generate_systemd.py'
+      - 'tests/integration/targets/podman_generate_systemd/**'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '.github/workflows/podman_generate_systemd.yml'
+      - 'ci/*.yml'
+      - 'ci/run_containers_tests.sh'
+      - 'ci/playbooks/containers/podman_generate_systemd.yml'
+      - 'plugins/modules/podman_generate_systemd.py'
+      - 'tests/integration/targets/podman_generate_systemd/**'
+  schedule:
+    - cron: 4 0 * * *  # Run daily at 0:03 UTC
+
+jobs:
+
+  test_podman_generate_systemd:
+    name: Podman generate systemd ${{ matrix.ansible-version }}-${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible-version:
+          - ansible<2.10
+          # - git+https://github.com/ansible/ansible.git@stable-2.11
+          - git+https://github.com/ansible/ansible.git@devel
+        os:
+          - ubuntu-22.04
+        python-version:
+          - 3.9
+
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip and display Python and PIP versions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python*-wheel python*-yaml
+          python -m pip install --upgrade pip
+          python -V
+          pip --version
+      - name: Set up pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ github.ref }}-units-VMs
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install Ansible ${{ matrix.ansible-version }}
+        run: python3 -m pip install --user --force-reinstall --upgrade '${{ matrix.ansible-version }}'
+
+      - name: Build and install the collection tarball
+        run: |
+          rm -rf /tmp/just_new_collection
+          ~/.local/bin/ansible-galaxy collection build --output-path /tmp/just_new_collection --force
+          ~/.local/bin/ansible-galaxy collection install -vvv --force /tmp/just_new_collection/*.tar.gz
+      - name: Run collection tests for Podman generate systemd
+        run: |
+          export PATH=~/.local/bin:$PATH
+          echo "Run ansible version"
+          command -v ansible
+          ansible --version
+          export ANSIBLE_CONFIG=$(pwd)/ci/ansible-dev.cfg
+          if [[ '${{ matrix.ansible-version }}'  == 'ansible<2.10' ]]; then
+            export ANSIBLE_CONFIG=$(pwd)/ci/ansible-2.9.cfg
+          fi
+          echo $ANSIBLE_CONFIG
+          command -v ansible-playbook
+          pip --version
+          python --version
+          ansible-playbook --version
+          ansible-playbook -vv ci/playbooks/pre.yml \
+          -e host=localhost \
+          -i localhost, \
+          -e ansible_connection=local \
+          -e setup_python=false
+          TEST2RUN=podman_generate_systemd ./ci/run_containers_tests.sh
+        shell: bash

--- a/ci/playbooks/containers/podman_generate_systemd.yml
+++ b/ci/playbooks/containers/podman_generate_systemd.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+    - include_role:
+        name: podman_generate_systemd
+      vars:
+        ansible_python_interpreter: "{{ _ansible_python_interpreter }}"

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -319,7 +319,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
             f' Command returned with code: {return_code}.'
             f' Error message: {stderr}.'
         )
-        return changed, {}
+        return changed, {}, f'{command}'
 
     # In case of command execution success, its stdout is a json
     # dictionary. This dictionary is all the generated systemd units.

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -277,35 +277,21 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     #  After option (only for Podman 4.0.0 and above)
     after = module.params.get('after')
     if after:
-        # If after is a single string
-        if isinstance(after, str):
-            command_options.append(f'--after={after}')
-        # If wants is a list
-        if isinstance(after, list):
-            for item in after:
-                command_options.append(f'--after={item}')
+        for item in after:
+            command_options.append(f'--after={item}')
 
     #  Wants option (only for Podman 4.0.0 and above)
     wants = module.params.get('wants')
     if wants:
-        # If wants is a single string
-        if isinstance(wants, str):
-            command_options.append(f'--wants={wants}')
-        # If wants is a list
-        if isinstance(wants, list):
-            for item in wants:
-                command_options.append(f'--wants={item}')
+        for item in wants:
+            command_options.append(f'--wants={item}')
                 
     #  Requires option (only for Podman 4.0.0 and above)
     requires = module.params.get('requires')
     if requires:
-        # If requires is a single string
-        if isinstance(requires, str):
-            command_options.append(f'--requires={requires}')
-        # If requires is a list
-        if isinstance(requires, list):
-            for item in requires:
-                command_options.append(f'--requires={item}')
+        for item in requires:
+            command_options.append(f'--requires={item}')
+
     
     #  Full command, with option include
     command_options.extend(['--format', 'json'])

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -223,6 +223,112 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str]]:
             )
     # Return the systemd .service unit(s) content
     return changed, systemd_units
+
+def run_module():
+    '''Run the module on the target'''
+    # Build the list of parameters user can use
+    module_parameters = {
+        'name': {
+            'type': 'str',
+            'required': True,
+        },
+        'dest': {
+            'type': 'str',
+            'required': False,
+        },
+        'new': {
+            'type': 'bool',
+            'required': False,
+            'default': False,
+        },
+        'restart_policy': {
+            'type': 'str',
+            'required': False,
+            'default': 'on-failure',
+            'choices': RESTART_POLICY_CHOICES,
+        },
+        'restart_sec': {
+            'type': 'int',
+            'required': False,
+        },
+        'start_timeout': {
+            'type': 'int',
+            'required': False,
+        },
+        'stop_timeout': {
+            'type': 'int',
+            'required': False,
+        },
+        'use_names': {
+            'type': 'bool',
+            'required': False,
+            'default': True,
+        },
+        'container_prefix': {
+            'type': 'str',
+            'required': False,
+        },
+        'pod_prefix': {
+            'type': 'str',
+            'required': False,
+        },
+        'separator': {
+            'type': 'str',
+            'required': False,
+        },
+        'no_header': {
+            'type': 'bool',
+            'required': False,
+            'default': False,
+        },
+        'after': {
+            'type': 'list',
+            'elements': 'str',
+            'required': False,
+        },
+        'wants': {
+            'type': 'list',
+            'elements': 'str',
+            'required': False,
+        },
+        'requires': {
+            'type': 'list',
+            'elements': 'str',
+            'required': False,
+        },
+        'debug': {
+            'type': 'bool',
+            'required': False,
+            'default': False,
+        },
+        'executable': {
+            'type': 'str',
+            'required': False,
+            'default': 'podman',
+        },
+    }
+    
+    # Build result dictionary
+    result = {
+        'changed': False,
+        'systemd_units': {},
+    }
+
+    # Build the Ansible Module
+    module = AnsibleModule(
+        argument_spec=module_parameters,
+        supports_check_mode=True
+    )
+
+    # Generate the systemd units
+    state_changed, systemd_units = generate_systemd(module)
+
+    result['changed'] = state_changed
+    result['systemd_units'] = systemd_units
+
+    # Return the result
+    module.exit_json(**result)
+
 def main():
     pass
 

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -319,7 +319,6 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
             f' Command returned with code: {return_code}.'
             f' Error message: {stderr}.'
         )
-        return changed, {}, f'{command}'
 
     # In case of command execution success, its stdout is a json
     # dictionary. This dictionary is all the generated systemd units.

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -221,6 +221,8 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str]]:
                 'Error writing systemd units files: '
                 f'{exception}'
             )
+    # Return the systemd .service unit(s) content
+    return changed, systemd_units
 def main():
     pass
 

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -31,6 +31,7 @@ options:
       - Refer to podman-generate-systemd(1) man page for more information.
     type: bool
     required: false
+    default: false
   restart_policy:
     description:
       - Restart policy of the service
@@ -69,7 +70,7 @@ options:
       - Only with Podman 4.3.0 and above
     type: dict
     required: false
-  use_name:
+  use_names:
     description:
       - Use name of the containers for the start, stop, and description in the unit file.
     type: bool

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -234,14 +234,14 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     '''
     # Flag which indicate whether the targeted system state is modified
     changed = False
-    
+
     # Build the podman command, based on the module parameters
     command_options = []
 
     #  New option
     if module.params.get('new'):
         command_options.append('--new')
-    
+
     #  Restart policy option
     restart_policy = module.params.get('restart_policy')
     if restart_policy:
@@ -304,7 +304,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     if wants:
         for item in wants:
             command_options.append(f'--wants={item}')
-                
+
     #  Requires option (only for Podman 4.0.0 and above)
     requires = module.params.get('requires')
     if requires:
@@ -318,7 +318,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
             command_options.append(
                 f"-e='{env_var_name}={env_var_value}'",
             )
-    
+
     #  Full command, with option include
     command_options.extend(['--format', 'json'])
     command = [
@@ -327,7 +327,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
         module.params['name'],
     ]
     command_str = ' '.join(command)
-    
+
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)
 
@@ -348,7 +348,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
 
     # Load the returned json dictionary as a python dictionary
     systemd_units = json.loads(stdout)
-    
+
     # Write the systemd .service unit(s) content to file(s), if
     # requested and not in check mode
     if module.params.get('dest') and not module.check_mode:
@@ -375,7 +375,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
                     systemd_units_dest,
                     unit_file_name,
                 )
-                
+
                 # See if we need to write the unit file, default yes
                 need_to_write_file = True
                 # If the unit file already exist, compare it with the
@@ -383,7 +383,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
                 if os.path.exists(unit_file_full_path):
                     # Read the file
                     with open(unit_file_full_path, 'r') as unit_file:
-                        current_unit_file_content = unit_file.read()                    
+                        current_unit_file_content = unit_file.read()
                     # If current unit file content is the same as the
                     # generated content
                     if current_unit_file_content == unit_content:
@@ -488,7 +488,7 @@ def run_module():
             'default': 'podman',
         },
     }
-    
+
     # Build result dictionary
     result = {
         'changed': False,

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -221,7 +221,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
         # If the restart policy requested is not supported by podman
         if restart_policy not in RESTART_POLICY_CHOICES:
             # Then stop the module execution and return an error message
-            modul.fail_json(
+            module.fail_json(
                 msg=f'Restart policy requested is "{restart_policy}"'
                 f',  but must be one of: {RESTART_POLICY_CHOICES}'
             )

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -2,7 +2,6 @@
 
 # 2022, Sébastien Gendre <seb@k-7.ch>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from __future__ import absolute_import, division, print_function
 
 # TODO: Write DOCUMENTATION, EXAMPLES and RETURN
 

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# 2022, Sébastien Gendre <seb@k-7.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+# TODO: Write DOCUMENTATION, EXAMPLES and RETURN
+
+DOCUMENTATION = '''
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+import os
+
+def generate_systemd():
+    """Generate systemd .service unit file from a pod or container"""
+    pass
+
+
+def main():
+    pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -145,6 +145,19 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str]]:
         module.log('PODMAN-GENERATE-SYSTEMD-DEBUG:'
                    f' Command for generate systemd .service unit: {command}')
     
+    # Run the podman command to generated systemd .service unit(s) content
+    return_code, stdout, stderr = module.run_command(command)
+
+    # In case of error in running the command
+    if return_code != 0:
+        # Print informations about the error and return and empty dictionary
+        module.fail_json(
+            'Error generating systemd .service unit(s).'
+            f' Command executed: {command}'
+            f' Command returned with code: {return_code}.'
+            f' Error message: {stderr}.'
+        )
+        return changed, {}
 
 def main():
     pass

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -251,7 +251,10 @@ def generate_systemd(module):
             # Then stop the module execution and return an error message
             module.fail_json(
                 msg=f'Restart policy requested is "{restart_policy}"'
-                f',  but must be one of: {RESTART_POLICY_CHOICES}'
+                f',  but must be one of: {RESTART_POLICY_CHOICES}',
+                changed=changed,
+                systemd_units={},
+                podman_command='',
             )
         # Else add the restart policy to options
         if restart_policy == 'no-restart':
@@ -338,10 +341,13 @@ def generate_systemd(module):
     if return_code != 0:
         # Print informations about the error and return and empty dictionary
         module.fail_json(
-            'Error generating systemd .service unit(s).'
+            msg='Error generating systemd .service unit(s).'
             f' Command executed: {command_str}'
             f' Command returned with code: {return_code}.'
-            f' Error message: {stderr}.'
+            f' Error message: {stderr}.',
+            changed=changed,
+            systemd_units={},
+            podman_command=command_str,
         )
 
     # In case of command execution success, its stdout is a json
@@ -366,8 +372,11 @@ def generate_systemd(module):
             if not os.path.isdir(systemd_units_dest):
                 # Stop and tell user that the destination is not a directry
                 module.fail_json(
-                    f'Destination {systemd_units_dest} is not a directory.'
-                    "Can't save systemd unit files in."
+                    msg=f'Destination {systemd_units_dest} is not a directory.'
+                    "Can't save systemd unit files in.",
+                    changed=changed,
+                    systemd_units=systemd_units,
+                    podman_command=command_str,
                 )
 
             # Write each systemd unit, if needed

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -343,15 +343,21 @@ def generate_systemd(module):
                 ),
             )
 
-    #  Full command, with option include
+    #   Set output format, of podman command, to json
     command_options.extend(['--format', 'json'])
+
+    #  Full command build, with option included    
+    #   Base of the command
     command = [
         module.params['executable'], 'generate', 'systemd',
-        *command_options,
-        module.params['name'],
     ]
+    #   Add the options to the commande
+    command.extend(command_options)
+    #   Add pod or container name to the command
+    command.append(module.params['name'])
+    #   Build the string version of the command, only for module return
     command_str = ' '.join(command)
-
+    
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)
 

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# coding: utf-8 -*-
 
 # 2022, Sébastien Gendre <seb@k-7.ch>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -406,7 +406,6 @@ def run_module():
         'restart_policy': {
             'type': 'str',
             'required': False,
-            'default': 'on-failure',
             'choices': RESTART_POLICY_CHOICES,
         },
         'restart_sec': {

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -45,11 +45,13 @@ options:
     description:
       - Configures the time to sleep before restarting a service (as configured with restart-policy).
       - Takes a value in seconds.
+      - Only with Podman 4.0.0 and above
     type: int
     required: false
   start_timeout:
     description:
       - Override the default start timeout for the container with the given value in seconds.
+      - Only with Podman 4.0.0 and above
     type: int
     required: false
   stop_timeout:
@@ -96,6 +98,7 @@ options:
       - This option may be specified more than once.
       - User-defined dependencies will be appended to the generated unit file
       - But any existing options such as needed or defined by default (e.g. C(online.target)) will not be removed or overridden.
+      - Only with Podman 4.0.0 and above
     type: list
     elements: str
     required: false
@@ -106,6 +109,7 @@ options:
       - This option does not influence the order in which services are started or stopped.
       - User-defined dependencies will be appended to the generated unit file
       - But any existing options such as needed or defined by default (e.g. C(online.target)) will not be removed or overridden.
+      - Only with Podman 4.0.0 and above
     type: list
     elements: str
     required: false
@@ -113,6 +117,7 @@ options:
     description:
       - Set the systemd unit requires (Requires=) option.
       - Similar to wants, but declares a stronger requirement dependency.
+      - Only with Podman 4.0.0 and above
     type: list
     elements: str
     required: false

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -2,6 +2,9 @@
 
 # 2022, Sébastien Gendre <seb@k-7.ch>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 
 DOCUMENTATION = '''
 module: podman_generate_systemd

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -23,7 +23,7 @@ options:
   dest:
     description:
       - Destination of the generated systemd unit file(s)
-    type: str
+    type: path
     required: false
   new:
     description:

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -142,10 +142,12 @@ EXAMPLES = '''
     name: postgres_local
     image: docker.io/library/postgres:latest
     state: stopped
+
 - name: Systemd unit files for postgres container must exist
   containers.podman.podman_generate_systemd:
     name: postgres_local
     path: ~/.config/systemd/user/
+
 - name: Postgres container must be started and enabled on systemd
   ansible.builtin.systemd:
     name: container-postgres_local

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -137,7 +137,7 @@ notes:
   - If a container or pod is already started before you do a C(systemctl daemon reload),
     systemd will not see the container or pod as started
   - Stop your container or pod before you do a C(systemctl daemon reload),
-    then you can start them with C(systemctl start my_container.servic)
+    then you can start them with C(systemctl start my_container.service)
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -3,8 +3,6 @@
 # 2022, Sébastien Gendre <seb@k-7.ch>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: Write DOCUMENTATION, EXAMPLES and RETURN
-
 DOCUMENTATION = '''
 module: podman_generate_systemd
 author:

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -235,22 +235,38 @@ def generate_systemd(module):
         # add the restart policy to options
         if restart_policy == 'no-restart':
             restart_policy = 'no'
-        command_options.append(f'--restart-policy={restart_policy}')
+        command_options.append(
+            '--restart-policy={restart_policy}'.format(
+                restart_policy=restart_policy,
+            ),
+        )
 
     #  Restart-sec option (only for Podman 4.0.0 and above)
     restart_sec = module.params['restart_sec']
     if restart_sec:
-        command_options.append(f'--restart-sec={restart_sec}')
+        command_options.append(
+            '--restart-sec={restart_sec}'.format(
+                restart_sec=restart_sec,
+            ),
+        )
 
     #  Start-timeout option (only for Podman 4.0.0 and above)
     start_timeout = module.params['start_timeout']
     if start_timeout:
-        command_options.append(f'--start-timeout={start_timeout}')
+        command_options.append(
+            '--start-timeout={start_timeout}'.format(
+                start_timeout=start_timeout,
+            ),
+        )
 
     #  Stop-timeout option
     stop_timeout = module.params['stop_timeout']
     if stop_timeout:
-        command_options.append(f'--stop-timeout={stop_timeout}')
+        command_options.append(
+            '--stop-timeout={stop_timeout}'.format(
+                stop_timeout=stop_timeout,
+            ),
+        )
 
     #  Use container name(s) option
     if module.params['use_names']:
@@ -259,17 +275,29 @@ def generate_systemd(module):
     #  Container-prefix option
     container_prefix = module.params['container_prefix']
     if container_prefix:
-        command_options.append(f'--container-prefix={container_prefix}')
+        command_options.append(
+            '--container-prefix={container_prefix}'.format(
+                container_prefix=container_prefix,
+            ),
+        )
 
     #  Pod-prefix option
     pod_prefix = module.params['pod_prefix']
     if pod_prefix:
-        command_options.append(f'--pod-prefix={pod_prefix}')
+        command_options.append(
+            '--pod-prefix={pod_prefix}'.format(
+                pod_prefix=pod_prefix,
+            ),
+        )
 
     #  Separator option
     separator = module.params['separator']
     if separator:
-        command_options.append(f'--separator={separator}')
+        command_options.append(
+            '--separator={separator}'.format(
+                separator=separator,
+            ),
+        )
 
     #  No-header option
     if module.params['no_header']:
@@ -279,26 +307,41 @@ def generate_systemd(module):
     after = module.params['after']
     if after:
         for item in after:
-            command_options.append(f'--after={item}')
+            command_options.append(
+                '--after={item}'.format(
+                    item=item,
+                ),
+            )
 
     #  Wants option (only for Podman 4.0.0 and above)
     wants = module.params['wants']
     if wants:
         for item in wants:
-            command_options.append(f'--wants={item}')
+            command_options.append(
+                '--wants={item}'.format(
+                    item=item,
+                )
+            )
 
     #  Requires option (only for Podman 4.0.0 and above)
     requires = module.params['requires']
     if requires:
         for item in requires:
-            command_options.append(f'--requires={item}')
+            command_options.append(
+                '--requires={item}'.format(
+                    item=item,
+                ),
+            )
 
     # Environment variables (only for Podman 4.3.0 and above)
     environment_variables = module.params['env']
     if environment_variables:
         for env_var_name, env_var_value in environment_variables.items():
             command_options.append(
-                f"-e='{env_var_name}={env_var_value}'",
+                "-e='{env_var_name}={env_var_value}'".format(
+                    env_var_name=env_var_name,
+                    env_var_value=env_var_value,
+                ),
             )
 
     #  Full command, with option include
@@ -316,11 +359,16 @@ def generate_systemd(module):
     # In case of error in running the command
     if return_code != 0:
         # Print informations about the error and return and empty dictionary
+        message = 'Error generating systemd .service unit(s).'
+        message += ' Command executed: {command_str}'
+        message += ' Command returned with code: {return_code}.'
+        message += ' Error message: {stderr}.'
         module.fail_json(
-            msg='Error generating systemd .service unit(s).'
-            f' Command executed: {command_str}'
-            f' Command returned with code: {return_code}.'
-            f' Error message: {stderr}.',
+            msg=message.format(
+                command_str=command_str,
+                return_code=return_code,
+                stderr=stderr,
+            ),
             changed=changed,
             systemd_units={},
             podman_command=command_str,
@@ -347,9 +395,12 @@ def generate_systemd(module):
             # If destination exist but not a directory
             if not os.path.isdir(systemd_units_dest):
                 # Stop and tell user that the destination is not a directry
+                message = "Destination {systemd_units_dest} is not a directory."
+                message += " Can't save systemd unit files in."
                 module.fail_json(
-                    msg=f"Destination {systemd_units_dest} is not a directory."
-                    "Can't save systemd unit files in.",
+                    msg=message.format(
+                        systemd_units_dest=systemd_units_dest,
+                    ),
                     changed=changed,
                     systemd_units=systemd_units,
                     podman_command=command_str,
@@ -386,10 +437,13 @@ def generate_systemd(module):
 
         except Exception as exception:
             # When exception occurs while trying to write units file
+            message = 'PODMAN-GENERATE-SYSTEMD-DEBUG: '
+            message += 'Error writing systemd units files: '
+            message += '{exception}'
             module.log(
-                'PODMAN-GENERATE-SYSTEMD-DEBUG: '
-                'Error writing systemd units files: '
-                f'{exception}'
+                message.format(
+                    exception=exception
+                ),
             )
     # Return the systemd .service unit(s) content
     return changed, systemd_units, command_str

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -18,10 +18,133 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 import json
 
-def generate_systemd():
-    """Generate systemd .service unit file from a pod or container"""
-    pass
+RESTART_POLICY_CHOICES = [
+    'no',
+    'on-success',
+    'on-failure',
+    'on-abnormal',
+    'on-watchdog',
+    'on-abort',
+    'always',
+]
 
+def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str]]:
+    '''Generate systemd .service unit file from a pod or container.
+
+    Parameter:
+    - module: An AnsibleModule object
+
+    Returns:
+    - A boolean which indicate whether the targeted systemd state is modified
+    - A copy of the generated systemd .service units content
+    '''
+    # Flag which indicate whether the targeted system state is modified
+    changed = False
+    
+    # Build the podman command, based on the module parameters
+    command_options = []
+
+    #  New option
+    if module.params.get('new'):
+        command_options.append('--new')
+    
+    #  Restart policy option
+    restart_policy = module.params.get('restart_policy')
+    if restart_policy:
+        # If the restart policy requested is not supported by podman
+        if restart_policy not in RESTART_POLICY_CHOICES:
+            # Then stop the module execution and return an error message
+            modul.fail_json(
+                msg=f'Restart policy requested is "{restart_policy}"'
+                f',  but must be one of: {RESTART_POLICY_CHOICES}'
+            )
+        # Else add the restart policy to options
+        command_options.append(f'--restart-policy={restart_policy}')
+
+    #  Restart-sec option (only for Podman 4.0.0 and above)
+    restart_sec = module.params.get('restart_sec')
+    if restart_sec:
+        command_options.append(f'--restart-sec={restart_sec}')
+
+    #  Start-timeout option (only for Podman 4.0.0 and above)
+    start_timeout = module.params.get('start_timeout')
+    if start_timeout:
+        command_options.append(f'--start-timeout={start_timeout}')
+
+    #  Stop-timeout option
+    stop_timeout = module.params.get('stop_timeout')
+    if stop_timeout:
+        command_options.append(f'--stop-timeout={stop_timeout}')
+
+    #  Use container name(s) option
+    if module.params.get('use_names'):
+        command_options.append('--name')
+
+    #  Container-prefix option
+    container_prefix = module.params.get('container_prefix')
+    if container_prefix:
+        command_options.append(f'--container-prefix={container_prefix}')
+
+    #  Pod-prefix option
+    pod_prefix = module.params.get('pod_prefix')
+    if pod_prefix:
+        command_options.append(f'--pod-prefix={pod_prefix}')
+
+    #  Separator option
+    separator = module.params.get('separator')
+    if separator:
+        command_options.append(f'--separator={separator}')
+
+    #  No-header option
+    if module.params.get('no_header'):
+        command_options.append('--no-header')
+
+    #  After option (only for Podman 4.0.0 and above)
+    after = module.params.get('after')
+    if after:
+        # If after is a single string
+        if isinstance(after, str):
+            command_options.append(f'--after={after}')
+        # If wants is a list
+        if isinstance(after, list):
+            for item in after:
+                command_options.append(f'--after={item}')
+
+    #  Wants option (only for Podman 4.0.0 and above)
+    wants = module.params.get('wants')
+    if wants:
+        # If wants is a single string
+        if isinstance(wants, str):
+            command_options.append(f'--wants={wants}')
+        # If wants is a list
+        if isinstance(wants, list):
+            for item in wants:
+                command_options.append(f'--wants={item}')
+                
+    #  Requires option (only for Podman 4.0.0 and above)
+    requires = module.params.get('requires')
+    if requires:
+        # If requires is a single string
+        if isinstance(requires, str):
+            command_options.append(f'--requires={requires}')
+        # If requires is a list
+        if isinstance(requires, list):
+            for item in requires:
+                command_options.append(f'--requires={item}')
+    
+    #  Full command, with option include
+    command_options.extend(['--format', 'json'])
+    command = [
+        module.params.get('executable'), 'generate', 'systemd',
+        *command_options,
+        module.params['name'],
+    ]
+
+    # If debug enabled
+    if module.params.get('debug'):
+        module.log('PODMAN-GENERATE-SYSTEMD-DEBUG:'
+                   f' Command for generate systemd .service unit: {command}')
+    
 
 def main():
     pass

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -353,7 +353,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     # requested and not in check mode
     if module.params.get('dest') and not module.check_mode:
         try:
-            systemd_units_dest = os.path.expanduser(module.params.get('dest'))
+            systemd_units_dest = module.params.get('dest')
             # If destination don't exist and not in check mode
             if not os.path.exists(systemd_units_dest):
                 # Make it
@@ -416,7 +416,7 @@ def run_module():
             'required': True,
         },
         'dest': {
-            'type': 'str',
+            'type': 'path',
             'required': False,
         },
         'new': {

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -231,17 +231,7 @@ def generate_systemd(module):
     #  Restart policy option
     restart_policy = module.params.get('restart_policy')
     if restart_policy:
-        # If the restart policy requested is not supported by podman
-        if restart_policy not in RESTART_POLICY_CHOICES:
-            # Then stop the module execution and return an error message
-            module.fail_json(
-                msg=f'Restart policy requested is "{restart_policy}"'
-                f',  but must be one of: {RESTART_POLICY_CHOICES}',
-                changed=changed,
-                systemd_units={},
-                podman_command='',
-            )
-        # Else add the restart policy to options
+        # add the restart policy to options
         if restart_policy == 'no-restart':
             restart_policy = 'no'
         command_options.append(f'--restart-policy={restart_policy}')

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -346,7 +346,7 @@ def generate_systemd(module):
     #   Set output format, of podman command, to json
     command_options.extend(['--format', 'json'])
 
-    #  Full command build, with option included    
+    #  Full command build, with option included
     #   Base of the command
     command = [
         module.params['executable'], 'generate', 'systemd',
@@ -357,7 +357,7 @@ def generate_systemd(module):
     command.append(module.params['name'])
     #   Build the string version of the command, only for module return
     command_str = ' '.join(command)
-    
+
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)
 

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -6,6 +6,135 @@
 # TODO: Write DOCUMENTATION, EXAMPLES and RETURN
 
 DOCUMENTATION = '''
+module: podman_generate_systemd
+author:
+  - Sébastien Gendre
+short_description: Generate systemd unit from a pod or a container
+description:
+  - Generate systemd .service unit file(s) from a pod or a container
+  - Support Ansible check mode
+options:
+  name:
+    description:
+      - Name of the pod or container to export
+    type: str
+    required: true
+  dest:
+    description:
+      - Destination of the generated systemd unit file(s)
+    type: str
+    required: false
+  new:
+    description:
+      - Generate unit files that create containers and pods, not only start them.
+      - Refer to podman-generate-systemd(1) man page for more information.
+    type: bool
+    required: false
+  restart_policy:
+    description:
+      - Restart policy of the service
+    type: str
+    required: false
+    choices:
+      - no
+      - on-success
+      - on-failure
+      - on-abnormal
+      - on-watchdog
+      - on-abort
+      - always
+  restart_sec:
+    description:
+      - Configures the time to sleep before restarting a service (as configured with restart-policy).
+      - Takes a value in seconds.
+    type: int
+    required: false
+  start_timeout:
+    description:
+      - Override the default start timeout for the container with the given value in seconds.
+    type: int
+    required: false
+  stop_timeout:
+    description:
+      - Override the default stop timeout for the container with the given value in seconds.
+    type: int
+    required: false
+  use_name:
+    description:
+      - Use name of the containers for the start, stop, and description in the unit file.
+    type: bool
+    required: false
+    default: yes
+  container_prefix:
+    description:
+      - Set the systemd unit name prefix for containers.
+      - If not set, use the default defined by podman, C(container).
+      - Refer to podman-generate-systemd(1) man page for more information.
+    type: str
+    required: false
+  pod_prefix:
+    description:
+      - Set the systemd unit name prefix for pods.
+      - If not set, use the default defined by podman, C(pod).
+      - Refer to podman-generate-systemd(1) man page for more information.
+    type: str
+    required: false
+  separator:
+    description:
+      - Systemd unit name separator between the name/id of a container/pod and the prefix.
+      - If not set, use the default defined by podman, C(-).
+      - Refer to podman-generate-systemd(1) man page for more information.
+    type: str
+    required: false
+  no_header:
+    description:
+      - Do not generate the header including meta data such as the Podman version and the timestamp.
+    type: bool
+    required: false
+    default: no
+  after:
+    description:
+      - Add the systemd unit after (C(After=)) option, that ordering dependencies between the list of dependencies and this service.
+      - This option may be specified more than once.
+      - User-defined dependencies will be appended to the generated unit file
+      - But any existing options such as needed or defined by default (e.g. C(online.target)) will not be removed or overridden.
+    type: list
+    elements: str
+    required: false
+  wants:
+    description:
+      - Add the systemd unit wants (C(Wants=)) option, that this service is (weak) dependent on.
+      - This option may be specified more than once.
+      - This option does not influence the order in which services are started or stopped.
+      - User-defined dependencies will be appended to the generated unit file
+      - But any existing options such as needed or defined by default (e.g. C(online.target)) will not be removed or overridden.
+    type: list
+    elements: str
+    required: false
+  requires:
+    description:
+      - Set the systemd unit requires (Requires=) option.
+      - Similar to wants, but declares a stronger requirement dependency.
+    type: list
+    elements: str
+    required: false
+  executable:
+    description:
+      - C(Podman) executable name or full path
+    type: str
+    required: false
+    default: podman
+requirements:
+  - Podman installed on target host
+notes:
+  - You can store your systemd unit files in C(/etc/systemd/user/) for system wide usage
+  - Or you can store them in C(~/.config/systemd/user/) for usage at a specific user
+  - If you indicate a pod, the systemd units for it and all its containers will be generated
+  - Create all your pods, containers and their dependencies before generating the systemd files
+  - If a container or pod is already started before you do a C(systemctl daemon reload),
+    systemd will not see the container or pod as started
+  - Stop your container or pod before you do a C(systemctl daemon reload),
+    then you can start them with C(systemctl start my_container.servic)
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 module: podman_generate_systemd
 author:
-  - Sébastien Gendre
+  - Sébastien Gendre (@CyberFox001)
 short_description: Generate systemd unit from a pod or a container
 description:
   - Generate systemd .service unit file(s) from a pod or a container

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -388,14 +388,15 @@ def generate_systemd(module):
     systemd_units = json.loads(stdout)
 
     # Write the systemd .service unit(s) content to file(s), if
-    # requested and not in check mode
-    if module.params['dest'] and not module.check_mode:
+    # requested
+    if module.params['dest']:
         try:
             systemd_units_dest = module.params['dest']
-            # If destination don't exist and not in check mode
+            # If destination don't exist
             if not os.path.exists(systemd_units_dest):
-                # Make it
-                os.makedirs(systemd_units_dest)
+                # If  not in check mode, make it
+                if not module.check_mode:
+                    os.makedirs(systemd_units_dest)
                 changed = True
             # If destination exist but not a directory
             if not os.path.isdir(systemd_units_dest):
@@ -437,7 +438,9 @@ def generate_systemd(module):
                 # Write the file, if needed
                 if need_to_write_file:
                     with open(unit_file_full_path, 'w') as unit_file:
-                        unit_file.write(unit_content)
+                        # If not in check mode, write the file
+                        if not module.check_mode:
+                            unit_file.write(unit_content)
                         changed = True
 
         except Exception as exception:

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -138,6 +138,30 @@ notes:
 '''
 
 EXAMPLES = '''
+# Exemple of creating a container and integrate it into systemd
+- name: A postgres container must exist, stopped
+  containers.podman.podman_container:
+    name: postgres_local
+    image: docker.io/library/postgres:latest
+    state: stopped
+- name: Systemd unit files for postgres container must exist
+  containers.podman.podman_generate_systemd:
+    name: postgres_local
+    path: ~/.config/systemd/user/
+- name: Postgres container must be started and enabled on systemd
+  ansible.builtin.systemd:
+    name: container-postgres_local
+    daemon_reload: yes
+    state: started
+    enabled: yes
+
+
+# Generate the unit files, but store them on an Ansible variable
+# instead of writting them on target host
+- name: Systemd unit files for postgres container must be generated
+  containers.podman.podman_generate_systemd:
+    name: postgres_local
+  register: postgres_local_systemd_unit
 '''
 
 RETURN = '''

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -178,9 +178,11 @@ podman_command:
   sample: "podman generate systemd my_webapp"
 '''
 
+
 import os
 from ansible.module_utils.basic import AnsibleModule
 import json
+
 
 RESTART_POLICY_CHOICES = [
     'no',
@@ -191,6 +193,7 @@ RESTART_POLICY_CHOICES = [
     'on-abort',
     'always',
 ]
+
 
 def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     '''Generate systemd .service unit file from a pod or container.
@@ -383,6 +386,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     # Return the systemd .service unit(s) content
     return changed, systemd_units, f'{command}'
 
+
 def run_module():
     '''Run the module on the target'''
     # Build the list of parameters user can use
@@ -484,9 +488,11 @@ def run_module():
     # Return the result
     module.exit_json(**result)
 
+
 def main():
     '''Main function of this script.'''
     run_module()
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -330,7 +330,8 @@ def run_module():
     module.exit_json(**result)
 
 def main():
-    pass
+    '''Main function of this script.'''
+    run_module()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -194,6 +194,7 @@ podman_command:
 import os
 from ansible.module_utils.basic import AnsibleModule
 import json
+import shlex
 
 
 RESTART_POLICY_CHOICES = [
@@ -307,7 +308,7 @@ def generate_systemd(module):
         *command_options,
         module.params['name'],
     ]
-    command_str = ' '.join(command)
+    command_str = shlex.join(command)
 
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -221,13 +221,13 @@ RESTART_POLICY_CHOICES = [
 ]
 
 
-def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
+def generate_systemd(module):
     '''Generate systemd .service unit file from a pod or container.
 
     Parameter:
-    - module: An AnsibleModule object
+    - module (AnsibleModule): An AnsibleModule object
 
-    Returns:
+    Returns (tuple[bool, list[str], str]):
     - A boolean which indicate whether the targeted systemd state is modified
     - A copy of the generated systemd .service units content
     - A copy of the command, as a string

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -25,19 +25,16 @@ options:
     description:
       - Destination of the generated systemd unit file(s)
     type: path
-    required: false
   new:
     description:
       - Generate unit files that create containers and pods, not only start them.
       - Refer to podman-generate-systemd(1) man page for more information.
     type: bool
-    required: false
     default: false
   restart_policy:
     description:
       - Restart policy of the service
     type: str
-    required: false
     choices:
       - no-restart
       - on-success
@@ -52,30 +49,25 @@ options:
       - Takes a value in seconds.
       - Only with Podman 4.0.0 and above
     type: int
-    required: false
   start_timeout:
     description:
       - Override the default start timeout for the container with the given value in seconds.
       - Only with Podman 4.0.0 and above
     type: int
-    required: false
   stop_timeout:
     description:
       - Override the default stop timeout for the container with the given value in seconds.
     type: int
-    required: false
   env:
     description:
       - Set environment variables to the systemd unit files.
       - Keys are the environment variable names, and values are the environment variable values
       - Only with Podman 4.3.0 and above
     type: dict
-    required: false
   use_names:
     description:
       - Use name of the containers for the start, stop, and description in the unit file.
     type: bool
-    required: false
     default: yes
   container_prefix:
     description:
@@ -83,26 +75,22 @@ options:
       - If not set, use the default defined by podman, C(container).
       - Refer to podman-generate-systemd(1) man page for more information.
     type: str
-    required: false
   pod_prefix:
     description:
       - Set the systemd unit name prefix for pods.
       - If not set, use the default defined by podman, C(pod).
       - Refer to podman-generate-systemd(1) man page for more information.
     type: str
-    required: false
   separator:
     description:
       - Systemd unit name separator between the name/id of a container/pod and the prefix.
       - If not set, use the default defined by podman, C(-).
       - Refer to podman-generate-systemd(1) man page for more information.
     type: str
-    required: false
   no_header:
     description:
       - Do not generate the header including meta data such as the Podman version and the timestamp.
     type: bool
-    required: false
     default: no
   after:
     description:
@@ -113,7 +101,6 @@ options:
       - Only with Podman 4.0.0 and above
     type: list
     elements: str
-    required: false
   wants:
     description:
       - Add the systemd unit wants (C(Wants=)) option, that this service is (weak) dependent on.
@@ -124,7 +111,6 @@ options:
       - Only with Podman 4.0.0 and above
     type: list
     elements: str
-    required: false
   requires:
     description:
       - Set the systemd unit requires (Requires=) option.
@@ -132,12 +118,10 @@ options:
       - Only with Podman 4.0.0 and above
     type: list
     elements: str
-    required: false
   executable:
     description:
       - C(Podman) executable name or full path
     type: str
-    required: false
     default: podman
 requirements:
   - Podman installed on target host

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -313,7 +313,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
     if environment_variables:
         for env_var_name, env_var_value in environment_variables.items():
             command_options.append(
-                f"--env '{env_var_name}={env_var_value}'",
+                f"-e='{env_var_name}={env_var_value}'",
             )
     
     #  Full command, with option include

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -194,7 +194,6 @@ podman_command:
 import os
 from ansible.module_utils.basic import AnsibleModule
 import json
-import shlex
 
 
 RESTART_POLICY_CHOICES = [
@@ -351,7 +350,7 @@ def generate_systemd(module):
         *command_options,
         module.params['name'],
     ]
-    command_str = shlex.join(command)
+    command_str = ' '.join(command)
 
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -68,7 +68,7 @@ options:
     description:
       - Use name of the containers for the start, stop, and description in the unit file.
     type: bool
-    default: yes
+    default: true
   container_prefix:
     description:
       - Set the systemd unit name prefix for containers.
@@ -91,7 +91,7 @@ options:
     description:
       - Do not generate the header including meta data such as the Podman version and the timestamp.
     type: bool
-    default: no
+    default: false
   after:
     description:
       - Add the systemd unit after (C(After=)) option, that ordering dependencies between the list of dependencies and this service.

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # 2022, Sébastien Gendre <seb@k-7.ch>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -165,6 +165,19 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+systemd_units:
+  description: A copy of the generated systemd .service unit(s)
+  returned: always
+  type: dict
+  sample: {
+    "container-postgres_local": " #Content of the systemd .servec unit for postgres_local container",
+    "pod-my_webapp": " #Content of the systemd .servec unit for my_webapp pod",
+    }
+podman_command:
+  description: A copy of the podman command used to generate the systemd unit(s)
+  returned: always
+  type: str
+  sample: "podman generate systemd my_webapp"
 '''
 
 import os

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -300,6 +300,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
         *command_options,
         module.params['name'],
     ]
+    command_str = ' '.join(command)
     
     # Run the podman command to generated systemd .service unit(s) content
     return_code, stdout, stderr = module.run_command(command)
@@ -309,7 +310,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
         # Print informations about the error and return and empty dictionary
         module.fail_json(
             'Error generating systemd .service unit(s).'
-            f' Command executed: {command}'
+            f' Command executed: {command_str}'
             f' Command returned with code: {return_code}.'
             f' Error message: {stderr}.'
         )
@@ -377,7 +378,7 @@ def generate_systemd(module: AnsibleModule) -> tuple[bool, list[str], str]:
                 f'{exception}'
             )
     # Return the systemd .service unit(s) content
-    return changed, systemd_units, f'{command}'
+    return changed, systemd_units, command_str
 
 
 def run_module():

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -38,7 +38,7 @@ options:
     type: str
     required: false
     choices:
-      - no
+      - no-restart
       - on-success
       - on-failure
       - on-abnormal
@@ -212,7 +212,7 @@ import json
 
 
 RESTART_POLICY_CHOICES = [
-    'no',
+    'no-restart',
     'on-success',
     'on-failure',
     'on-abnormal',
@@ -254,6 +254,8 @@ def generate_systemd(module):
                 f',  but must be one of: {RESTART_POLICY_CHOICES}'
             )
         # Else add the restart policy to options
+        if restart_policy == 'no-restart':
+            restart_policy = 'no'
         command_options.append(f'--restart-policy={restart_policy}')
 
     #  Restart-sec option (only for Podman 4.0.0 and above)

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -348,7 +348,7 @@ def generate_systemd(module):
             if not os.path.isdir(systemd_units_dest):
                 # Stop and tell user that the destination is not a directry
                 module.fail_json(
-                    msg=f'Destination {systemd_units_dest} is not a directory.'
+                    msg=f"Destination {systemd_units_dest} is not a directory."
                     "Can't save systemd unit files in.",
                     changed=changed,
                     systemd_units=systemd_units,

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -15,6 +15,8 @@ RETURN = '''
 '''
 
 import os
+from ansible.module_utils.basic import AnsibleModule
+import json
 
 def generate_systemd():
     """Generate systemd .service unit file from a pod or container"""

--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -225,11 +225,11 @@ def generate_systemd(module):
     command_options = []
 
     #  New option
-    if module.params.get('new'):
+    if module.params['new']:
         command_options.append('--new')
 
     #  Restart policy option
-    restart_policy = module.params.get('restart_policy')
+    restart_policy = module.params['restart_policy']
     if restart_policy:
         # add the restart policy to options
         if restart_policy == 'no-restart':
@@ -237,63 +237,63 @@ def generate_systemd(module):
         command_options.append(f'--restart-policy={restart_policy}')
 
     #  Restart-sec option (only for Podman 4.0.0 and above)
-    restart_sec = module.params.get('restart_sec')
+    restart_sec = module.params['restart_sec']
     if restart_sec:
         command_options.append(f'--restart-sec={restart_sec}')
 
     #  Start-timeout option (only for Podman 4.0.0 and above)
-    start_timeout = module.params.get('start_timeout')
+    start_timeout = module.params['start_timeout']
     if start_timeout:
         command_options.append(f'--start-timeout={start_timeout}')
 
     #  Stop-timeout option
-    stop_timeout = module.params.get('stop_timeout')
+    stop_timeout = module.params['stop_timeout']
     if stop_timeout:
         command_options.append(f'--stop-timeout={stop_timeout}')
 
     #  Use container name(s) option
-    if module.params.get('use_names'):
+    if module.params['use_names']:
         command_options.append('--name')
 
     #  Container-prefix option
-    container_prefix = module.params.get('container_prefix')
+    container_prefix = module.params['container_prefix']
     if container_prefix:
         command_options.append(f'--container-prefix={container_prefix}')
 
     #  Pod-prefix option
-    pod_prefix = module.params.get('pod_prefix')
+    pod_prefix = module.params['pod_prefix']
     if pod_prefix:
         command_options.append(f'--pod-prefix={pod_prefix}')
 
     #  Separator option
-    separator = module.params.get('separator')
+    separator = module.params['separator']
     if separator:
         command_options.append(f'--separator={separator}')
 
     #  No-header option
-    if module.params.get('no_header'):
+    if module.params['no_header']:
         command_options.append('--no-header')
 
     #  After option (only for Podman 4.0.0 and above)
-    after = module.params.get('after')
+    after = module.params['after']
     if after:
         for item in after:
             command_options.append(f'--after={item}')
 
     #  Wants option (only for Podman 4.0.0 and above)
-    wants = module.params.get('wants')
+    wants = module.params['wants']
     if wants:
         for item in wants:
             command_options.append(f'--wants={item}')
 
     #  Requires option (only for Podman 4.0.0 and above)
-    requires = module.params.get('requires')
+    requires = module.params['requires']
     if requires:
         for item in requires:
             command_options.append(f'--requires={item}')
 
     # Environment variables (only for Podman 4.3.0 and above)
-    environment_variables = module.params.get('env')
+    environment_variables = module.params['env']
     if environment_variables:
         for env_var_name, env_var_value in environment_variables.items():
             command_options.append(
@@ -303,7 +303,7 @@ def generate_systemd(module):
     #  Full command, with option include
     command_options.extend(['--format', 'json'])
     command = [
-        module.params.get('executable'), 'generate', 'systemd',
+        module.params['executable'], 'generate', 'systemd',
         *command_options,
         module.params['name'],
     ]
@@ -335,9 +335,9 @@ def generate_systemd(module):
 
     # Write the systemd .service unit(s) content to file(s), if
     # requested and not in check mode
-    if module.params.get('dest') and not module.check_mode:
+    if module.params['dest'] and not module.check_mode:
         try:
-            systemd_units_dest = module.params.get('dest')
+            systemd_units_dest = module.params['dest']
             # If destination don't exist and not in check mode
             if not os.path.exists(systemd_units_dest):
                 # Make it

--- a/tests/integration/targets/podman_generate_systemd/tasks/main.yml
+++ b/tests/integration/targets/podman_generate_systemd/tasks/main.yml
@@ -1,0 +1,112 @@
+---
+- name: Test podman generate systemd
+  block:
+    - name: A postgres container must exist, stopped
+      containers.podman.podman_container:
+        name: postgres_local
+        image: docker.io/library/postgres:latest
+        state: stopped
+
+    - name: Generate the systemd units as Ansible variables
+      containers.podman.podman_generate_systemd:
+        name: postgres_local
+      register: postgres_local_systemd_unit
+      ignore_errors: true
+
+    - name: Check systemd unit are generated
+      assert:
+        that:
+          - postgres_local_systemd_unit is succeeded
+
+    - name: Check content of systemd unit are correct
+      block:
+        - name: Check systemd unit exist in registered wars
+          assert:
+            that:
+              - "item.key" == "container-postgres_local"
+              - "item.value" != None
+      loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
+
+    - name: Check podman commande used to generate systemd units is returned
+      assert:
+        that:
+          - postgres_local_systemd_unit.command != ""
+
+    - name: Regenerate the systemd units and write them
+      containers.podman.podman_generate_systemd:
+        name: postgres_local
+        dest: /tmp/podman_generate_systemd
+      register: postgres_local_systemd_unit
+      ignore_errors: true
+
+    - name: Check unit files exist and content are the same
+      block:
+        - name: Check the file exist
+          ansible.builtin.stat:
+            path: "/tmp/podman_generate_systemd/{{ item.key }}.service"
+
+        - name: Get the file content
+          ansible.builtin.slurp:
+            src: "/tmp/podman_generate_systemd/{{ item.key }}.service"
+          register: systemd_file_content
+
+        - name: Check the content of the file is the same as the one generated
+          assert:
+            that:
+              - "{{ systemd_file_content }}" == "{{ item.value }}"          
+      loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
+
+    - name: Regenerate the systemd units with all the options
+      containers.podman.podman_generate_systemd:
+        name: postgres_local
+        new: yes
+        restart_policy: on-abnormal
+        restart_sec: 19
+        start_timeout: 21
+        stop_timeout: 23
+        env:
+          POSTGRES_USER: my_app
+          POSTGRES_PASSWORD: example
+        use_names: yes
+        container_prefix: more
+        pod_prefix: less
+        separator: %
+        no_header: yes
+        after: drink.service
+        wants: water.service
+        requires: ice.service
+        executable: /usr/bin/podman
+      register: postgres_local_systemd_unit
+      ignore_errors: true
+
+    - name: Check the correct podman command is build
+      assert:
+        that:
+          - "postgres_local" in postgres_local_systemd_unit.command
+          - "--new" in postgres_local_systemd_unit.command
+          - "--restart-policy=on-abnormal" in postgres_local_systemd_unit.command
+          - "--restart-sec=19" in postgres_local_systemd_unit.command
+          - "--start-timeout=21" in postgres_local_systemd_unit.command
+          - "--stop-timeout=23" in postgres_local_systemd_unit.command
+          - "--env 'POSTGRES_USER=my_app'" in postgres_local_systemd_unit.command
+          - "--env 'POSTGRES_PASSWORD=example'" in postgres_local_systemd_unit.command
+          - "--name" in postgres_local_systemd_unit.command
+          - "--container-prefix=more" in postgres_local_systemd_unit.command
+          - "--pod-prefix=less" in postgres_local_systemd_unit.command
+          - "--separator=%" in postgres_local_systemd_unit.command
+          - "--no-header" in postgres_local_systemd_unit.command
+          - "--after=drink.service" in postgres_local_systemd_unit.command
+          - "--wants=water.service" in postgres_local_systemd_unit.command
+          - "--requires=ice.service" in postgres_local_systemd_unit.command
+          - "/user/bin/podman" in postgres_local_systemd_unit.command
+      
+always:
+  - name: Remove container
+    containers.podman.podman_container:
+      executable: "{{ test_executable | default('podman') }}"
+      name: postgres_local
+      state: absent
+  - name: Remove the systemd unit files directory
+      ansible.builtin.file:
+        path: /tmp/podman_generate_systemd
+        state: absent

--- a/tests/integration/targets/podman_generate_systemd/tasks/main.yml
+++ b/tests/integration/targets/podman_generate_systemd/tasks/main.yml
@@ -1,112 +1,94 @@
----
-- name: Test podman generate systemd
-  block:
-    - name: A postgres container must exist, stopped
-      containers.podman.podman_container:
-        name: postgres_local
-        image: docker.io/library/postgres:latest
-        state: stopped
+- name: A postgres container must exist, stopped
+  containers.podman.podman_container:
+    name: postgres_local
+    image: docker.io/library/postgres:latest
+    state: stopped
 
-    - name: Generate the systemd units as Ansible variables
-      containers.podman.podman_generate_systemd:
-        name: postgres_local
-      register: postgres_local_systemd_unit
-      ignore_errors: true
+- name: Generate the systemd units as Ansible variables
+  containers.podman.podman_generate_systemd:
+    name: postgres_local
+  register: postgres_local_systemd_unit
+  ignore_errors: true
 
-    - name: Check systemd unit are generated
-      assert:
-        that:
-          - postgres_local_systemd_unit is succeeded
+- name: Check systemd unit are generated
+  assert:
+    that:
+      - postgres_local_systemd_unit is succeeded
 
-    - name: Check content of systemd unit are correct
-      block:
-        - name: Check systemd unit exist in registered wars
-          assert:
-            that:
-              - "item.key" == "container-postgres_local"
-              - "item.value" != None
-      loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
+- name: Check systemd unit exist in registered vars
+  assert:
+    that:
+      - item.key == "container-postgres_local"
+      - item.value != None
+  loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
 
-    - name: Check podman commande used to generate systemd units is returned
-      assert:
-        that:
-          - postgres_local_systemd_unit.command != ""
+- name: Check podman command used to generate systemd units is returned
+  assert:
+    that:
+      - postgres_local_systemd_unit.podman_command != ""
 
-    - name: Regenerate the systemd units and write them
-      containers.podman.podman_generate_systemd:
-        name: postgres_local
-        dest: /tmp/podman_generate_systemd
-      register: postgres_local_systemd_unit
-      ignore_errors: true
+- name: Regenerate the systemd units and write them
+  containers.podman.podman_generate_systemd:
+    name: postgres_local
+    dest: /tmp/podman_generate_systemd
+  register: postgres_local_systemd_unit
+  ignore_errors: true
 
-    - name: Check unit files exist and content are the same
-      block:
-        - name: Check the file exist
-          ansible.builtin.stat:
-            path: "/tmp/podman_generate_systemd/{{ item.key }}.service"
+- name: Check the unit files exists
+  ansible.builtin.stat:
+    path: "/tmp/podman_generate_systemd/{{ item.key }}.service"
+  loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
 
-        - name: Get the file content
-          ansible.builtin.slurp:
-            src: "/tmp/podman_generate_systemd/{{ item.key }}.service"
-          register: systemd_file_content
+- name: Regenerate the systemd units with all the options
+  containers.podman.podman_generate_systemd:
+    name: postgres_local
+    new: yes
+    restart_policy: on-abnormal
+    restart_sec: 19
+    start_timeout: 21
+    stop_timeout: 23
+    env:
+      POSTGRES_USER: my_app
+      POSTGRES_PASSWORD: example
+    use_names: yes
+    container_prefix: more
+    pod_prefix: less
+    separator: +
+    no_header: yes
+    after: drink.service
+    wants: water.service
+    requires: ice.service
+    executable: /usr/bin/podman
+  register: postgres_local_systemd_unit
+  ignore_errors: true
 
-        - name: Check the content of the file is the same as the one generated
-          assert:
-            that:
-              - "{{ systemd_file_content }}" == "{{ item.value }}"          
-      loop: "{{ postgres_local_systemd_unit.systemd_units | dict2items }}"
+- name: Check the correct podman command is build
+  assert:
+    that:
+      - postgres_local_systemd_unit.podman_command is search("postgres_local")
+      - postgres_local_systemd_unit.podman_command is search("--new")
+      - postgres_local_systemd_unit.podman_command is search("--restart-policy=on-abnormal")
+      - postgres_local_systemd_unit.podman_command is search("--restart-sec=19")
+      - postgres_local_systemd_unit.podman_command is search("--start-timeout=21")
+      - postgres_local_systemd_unit.podman_command is search("--stop-timeout=23")
+      - postgres_local_systemd_unit.podman_command is search("-e='POSTGRES_USER=my_app'")
+      - postgres_local_systemd_unit.podman_command is search("-e='POSTGRES_PASSWORD=example'")
+      - postgres_local_systemd_unit.podman_command is search("--name")
+      - postgres_local_systemd_unit.podman_command is search("--container-prefix=more")
+      - postgres_local_systemd_unit.podman_command is search("--pod-prefix=less")
+      - postgres_local_systemd_unit.podman_command is search("--separator=+")
+      - postgres_local_systemd_unit.podman_command is search("--no-header")
+      - postgres_local_systemd_unit.podman_command is search("--after=drink.service")
+      - postgres_local_systemd_unit.podman_command is search("--wants=water.service")
+      - postgres_local_systemd_unit.podman_command is search("--requires=ice.service")
+      - postgres_local_systemd_unit.podman_command is search("/usr/bin/podman")
 
-    - name: Regenerate the systemd units with all the options
-      containers.podman.podman_generate_systemd:
-        name: postgres_local
-        new: yes
-        restart_policy: on-abnormal
-        restart_sec: 19
-        start_timeout: 21
-        stop_timeout: 23
-        env:
-          POSTGRES_USER: my_app
-          POSTGRES_PASSWORD: example
-        use_names: yes
-        container_prefix: more
-        pod_prefix: less
-        separator: %
-        no_header: yes
-        after: drink.service
-        wants: water.service
-        requires: ice.service
-        executable: /usr/bin/podman
-      register: postgres_local_systemd_unit
-      ignore_errors: true
-
-    - name: Check the correct podman command is build
-      assert:
-        that:
-          - "postgres_local" in postgres_local_systemd_unit.command
-          - "--new" in postgres_local_systemd_unit.command
-          - "--restart-policy=on-abnormal" in postgres_local_systemd_unit.command
-          - "--restart-sec=19" in postgres_local_systemd_unit.command
-          - "--start-timeout=21" in postgres_local_systemd_unit.command
-          - "--stop-timeout=23" in postgres_local_systemd_unit.command
-          - "--env 'POSTGRES_USER=my_app'" in postgres_local_systemd_unit.command
-          - "--env 'POSTGRES_PASSWORD=example'" in postgres_local_systemd_unit.command
-          - "--name" in postgres_local_systemd_unit.command
-          - "--container-prefix=more" in postgres_local_systemd_unit.command
-          - "--pod-prefix=less" in postgres_local_systemd_unit.command
-          - "--separator=%" in postgres_local_systemd_unit.command
-          - "--no-header" in postgres_local_systemd_unit.command
-          - "--after=drink.service" in postgres_local_systemd_unit.command
-          - "--wants=water.service" in postgres_local_systemd_unit.command
-          - "--requires=ice.service" in postgres_local_systemd_unit.command
-          - "/user/bin/podman" in postgres_local_systemd_unit.command
-      
-always:
-  - name: Remove container
-    containers.podman.podman_container:
-      executable: "{{ test_executable | default('podman') }}"
-      name: postgres_local
-      state: absent
-  - name: Remove the systemd unit files directory
-      ansible.builtin.file:
-        path: /tmp/podman_generate_systemd
-        state: absent
+- name: Remove container
+  containers.podman.podman_container:
+    executable: "{{ test_executable | default('podman') }}"
+    name: postgres_local
+    state: absent
+- name: Remove the systemd unit files directory
+  ansible.builtin.file:
+    path: /tmp/podman_generate_systemd
+    state: absent


### PR DESCRIPTION
This pull request add a new module: `podman_generate_systemd`.

This module will generate systemd .service units for pods and containers.

In this Pull Request, I provide:
- The module code
- It's documentation
- An integration test


The module can be used to only generate the systemd .service units and
save them in an Ansible variable, or to create the unit files on the
host. It support the check mode.

If you specify a Pod, le unit for the pod and all its containers will
be generated.

The module support a lot of options:
- `name`: Name of the pod or container to export as systemd unit
- `dest`: Destination of the generated systemd unit file(s)
- `new`: Make the unit create the container before starting it
- `restart_policy`: Restart policy of the service
- `restart_sec`: Configures the time to sleep before restarting a service (as configured with restart-policy)
- `start_timeout`: Override the default start timeout for the container with the given value in seconds
- `stop_timeout`: Override the default stop timeout for the container with the given value in seconds
- `env`: Set environment variables to the systemd unit files, need Podman >= 4.3.0 to be used
- `use_name`: Use name of the containers for the start, stop, and description in the unit file
- `container_prefix`: Set the systemd unit name prefix for containers
- `pod_prefix`: Set the systemd unit name prefix for pods
- `separator`: Systemd unit name separator between the name/id of a container/pod and the prefix
- `no_header`: Do not generate the header including meta data such as the Podman version and the timestamp
- `after`: Add a systemd unit in the `after` option of the generated systemd unit, need Podman >= 4.0.0 to be used
- `wants`: Add a systemd unit in the `wants` option of the generated systemd unit, need Podman >= 4.0.0 to be used
- `requires`: Add a systemd unit in the `requires` option of the generated systemd unit, need Podman >= 4.0.0 to be used
- `executable`: Podman executable name or full path

In the return values, you get the generated systemd units and the
command who was run to generate thems.

I write my own function to generate the systemd units, not the already
existed function. But they are similar.