### PR TITLE
fix pod running status for older podman versions

### DIFF
--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -538,7 +538,6 @@ class PodmanPod:
         self.name = name
         self.stdout, self.stderr = '', ''
         self.info = self.get_info()
-        self.ps_info = self.get_ps()
         self.infra_info = self.get_infra_info()
         self.version = self._get_podman_version()
         self.diff = {}
@@ -574,9 +573,14 @@ class PodmanPod:
         """Return True if pod is running now."""
         if 'status' in self.info['State']:
             return self.info['State']['status'] == 'Running'
-        if 'status' in self.ps_info:
-            return self.ps_info['status'] == 'Running'
-        return self.info['State'] == 'Running'
+        elif isinstance(self.info['State'],str):
+            return self.info['State'] == 'Running'
+        # older podman versions don't have status in 'podman pod inspect'
+        # if other methods fail, use 'podman pod ps'
+        ps_info = self.get_ps()
+        if 'status' in ps_info:
+            return ps_info['status'] == 'Running'
+        return False
 
     @property
     def paused(self):

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -573,13 +573,12 @@ class PodmanPod:
         """Return True if pod is running now."""
         if 'status' in self.info['State']:
             return self.info['State']['status'] == 'Running'
-        if isinstance(self.info['State'], str):
-            return self.info['State'] == 'Running'
         # older podman versions (1.6.x) don't have status in 'podman pod inspect'
         # if other methods fail, use 'podman pod ps'
         ps_info = self.get_ps()
         if 'status' in ps_info:
             return ps_info['status'] == 'Running'
+        return self.info['State'] == 'Running'
 
     @property
     def paused(self):

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -538,6 +538,7 @@ class PodmanPod:
         self.name = name
         self.stdout, self.stderr = '', ''
         self.info = self.get_info()
+        self.ps_info = self.get_ps()
         self.infra_info = self.get_infra_info()
         self.version = self._get_podman_version()
         self.diff = {}
@@ -573,6 +574,8 @@ class PodmanPod:
         """Return True if pod is running now."""
         if 'status' in self.info['State']:
             return self.info['State']['status'] == 'Running'
+        if 'status' in self.ps_info:
+            return self.ps_info['status'] == 'Running'
         return self.info['State'] == 'Running'
 
     @property
@@ -597,6 +600,13 @@ class PodmanPod:
         rc, out, err = self.module.run_command(
             [self.module_params['executable'], b'pod', b'inspect', self.name])
         return json.loads(out) if rc == 0 else {}
+
+    def get_ps(self):
+        """Inspect pod process and gather info about it."""
+        # pylint: disable=unused-variable
+        rc, out, err = self.module.run_command(
+            [self.module_params['executable'], b'pod', b'ps', b'--format', b'json', b'--filter', b'name=' + self.name])
+        return json.loads(out)[0] if rc == 0 else {}
 
     def get_infra_info(self):
         """Inspect pod and gather info about it."""

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -573,14 +573,13 @@ class PodmanPod:
         """Return True if pod is running now."""
         if 'status' in self.info['State']:
             return self.info['State']['status'] == 'Running'
-        elif isinstance(self.info['State'],str):
+        if isinstance(self.info['State'], str):
             return self.info['State'] == 'Running'
-        # older podman versions don't have status in 'podman pod inspect'
+        # older podman versions (1.6.x) don't have status in 'podman pod inspect'
         # if other methods fail, use 'podman pod ps'
         ps_info = self.get_ps()
         if 'status' in ps_info:
             return ps_info['status'] == 'Running'
-        return False
 
     @property
     def paused(self):

--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -607,7 +607,7 @@ class PodmanPod:
         """Inspect pod process and gather info about it."""
         # pylint: disable=unused-variable
         rc, out, err = self.module.run_command(
-            [self.module_params['executable'], b'pod', b'ps', b'--format', b'json', b'--filter', b'name=' + self.name])
+            [self.module_params['executable'], b'pod', b'ps', b'--format', b'json', b'--filter', 'name=' + self.name])
         return json.loads(out)[0] if rc == 0 else {}
 
     def get_infra_info(self):


### PR DESCRIPTION
Older podman versions, such as podman 1.6.4 on CentOS 7, do not have the pod status in the 'podman pod inspect' output. Added an attribute and a method to PodmanPod to fetch the 'podman pod ps' output. Added an additional status check to the exising running property that uses the 'ps' info.

Fixes #499

Signed-off-by: antonc42 <antonc42@users.noreply.github.com>