### PR TITLE
fix for buildah improper remote target

### DIFF
--- a/plugins/connection/buildah.py
+++ b/plugins/connection/buildah.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
         default: inventory_hostname
         vars:
             - name: ansible_host
+            - name: inventory_hostname
 #        keyword:
 #            - name: hosts
       remote_user:


### PR DESCRIPTION
This fix is similar to the previous one from [#506](https://github.com/containers/ansible-podman-collections/pull/506), but in buildah.py connection plugin
Fix #541 