### PR TITLE
Add hooks-dir parameter for containers

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -66,6 +66,7 @@ ARGUMENTS_SPEC_CONTAINER = dict(
     healthcheck_retries=dict(type='int'),
     healthcheck_start_period=dict(type='str'),
     healthcheck_timeout=dict(type='str'),
+    hooks_dir=dict(type='list', elements='str'),
     hostname=dict(type='str'),
     http_proxy=dict(type='bool'),
     image_volume=dict(type='str', choices=['bind', 'tmpfs', 'ignore']),
@@ -405,6 +406,11 @@ class PodmanModuleParams:
     def addparam_healthcheck_timeout(self, c):
         return c + ['--healthcheck-timeout',
                     self.params['healthcheck_timeout']]
+
+    def addparam_hooks_dir(self, c):
+        for hook_dir in self.params['hooks_dir']:
+            c += ['--hooks-dir=%s' % hook_dir]
+        return c
 
     def addparam_hostname(self, c):
         return c + ['--hostname', self.params['hostname']]

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -415,6 +415,13 @@ options:
         is considered failed. Like start-period, the value can be expressed in
         a time format such as 1m22s. The default value is 30s
     type: str
+  hooks_dir:
+    description:
+      - Each .json file in the path configures a hook for Podman containers.
+        For more details on the syntax of the JSON files and the semantics of
+        hook injection, see oci-hooks(5). Can be set multiple times.
+    type: list
+    elements: str
   hostname:
     description:
       - Container host name. Sets the container host name that is available


### PR DESCRIPTION
Fix #539
No idempotency for now, not clear how to detect it from config.
Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>