### PR TITLE
Convert str to json format before evaluating length in `find_image()` and `inspect_image()`.

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -524,8 +524,9 @@ class PodmanImageManager(object):
             image_name = self.image_name
         args = ['image', 'ls', image_name, '--format', 'json']
         rc, images, err = self._run(args, ignore_errors=True)
+        images = json.loads(images)
         if len(images) > 0:
-            return json.loads(images)
+            return images
         else:
             return None
 
@@ -547,8 +548,9 @@ class PodmanImageManager(object):
             image_name = self.image_name
         args = ['inspect', image_name, '--format', 'json']
         rc, image_data, err = self._run(args)
+        image_data = json.loads(image_data)
         if len(image_data) > 0:
-            return json.loads(image_data)
+            return image_data
         else:
             return None
 


### PR DESCRIPTION
**Background**
During working on #563, I found some strange behaviors of `podman_image.find_image()` and `podman_image.inspect_image()`.
I guess this implementation is not as expected.

**Details**
These functions will execute `podman` commands such as `podman image ls <IMG_NAME> --format json` and `podman image inspect <IMG_NAME> --format json`.
The following snippet is from `find_image()`, and it looks `images` is expected to receive a list from `rc, images, err = self._run(args, ignore_errors=True) `. Then its length will be evaluated.
However, I believe that currently `images` is `str` type and it is `[]\n` if the target image doesn't exist on a server. So `len(image)` will be not zero, but 3 or more.
https://github.com/containers/ansible-podman-collections/blob/d5f7655464ed942a368e317f99e39bc14acf0794/plugins/modules/podman_image.py#L525-L528

I think that the expectation here is `len(image)` will be zero if the target image is absent.
Therefore, this PR fixes that and converts str to json format before evaluating its length in `find_image()` and `inspect_image()`.

