### PR TITLE
Run systemctl instead of podman when generating systemd units

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1354,6 +1354,7 @@ class PodmanContainer:
         self.version = self._get_podman_version()
         self.diff = {}
         self.actions = []
+        self.systemd_unit = ''
 
     @property
     def exists(self):
@@ -1452,6 +1453,40 @@ class PodmanContainer:
                     msg="Can't %s container %s" % (action, self.name),
                     stdout=out, stderr=err)
 
+    def _perform_systemd_action(self, action):
+        """Perform action with systemd.
+
+        Arguments:
+            action {str} -- action to perform - start, stop, restart, daemon-reload
+        """
+        unit_name = (self.info["Config"]["Labels"] or {}).get("PODMAN_SYSTEMD_UNIT", None)
+        if not unit_name:
+            return self._perform_action(action)
+
+        command_components = ["systemctl", action]
+        if action != 'daemon-reload':
+            command_components.append(unit_name)
+
+        full_cmd = " ".join(command_components)
+        self.actions.append(full_cmd)
+
+        if self.module.check_mode:
+            self.module.log(
+                "PODMAN-CONTAINER-DEBUG (check_mode): %s" % full_cmd)
+        else:
+            rc, out, err = self.module.run_command(full_cmd)
+            self.module.log("PODMAN-CONTAINER-DEBUG: %s" % full_cmd)
+            if self.module_params['debug']:
+                self.module.log("PODMAN-CONTAINER-DEBUG STDOUT: %s" % out)
+                self.module.log("PODMAN-CONTAINER-DEBUG STDERR: %s" % err)
+                self.module.log("PODMAN-CONTAINER-DEBUG RC: %s" % rc)
+            self.stdout = out
+            self.stderr = err
+            if rc != 0:
+                self.module.fail_json(
+                    msg="Can't %s container systemd unit %s" % (action, unit_name),
+                    stdout=out, stderr=err)
+
     def run(self):
         """Run the container."""
         self._perform_action('run')
@@ -1462,19 +1497,36 @@ class PodmanContainer:
 
     def stop(self):
         """Stop the container."""
-        self._perform_action('stop')
+        if self.module_params['generate_systemd']:
+            self._perform_systemd_action('stop')
+        else:
+            self._perform_action('stop')
 
     def start(self):
         """Start the container."""
-        self._perform_action('start')
+        if self.module_params['generate_systemd']:
+            if self.different:
+                self._perform_systemd_action('daemon-reload')
+            self._perform_systemd_action('start')
+        else:
+            self._perform_action('start')
 
     def restart(self):
         """Restart the container."""
-        self._perform_action('restart')
+        if self.module_params['generate_systemd']:
+            if self.different:
+                self._perform_systemd_action('daemon-reload')
+            self._perform_systemd_action('restart')
+        else:
+            self._perform_action('restart')
 
     def create(self):
         """Create the container."""
         self._perform_action('create')
+        self.systemd_unit = generate_systemd(self.module,
+                                             self.module_params,
+                                             self.name,
+                                             self.version)
 
     def recreate(self):
         """Recreate the container."""
@@ -1547,11 +1599,7 @@ class PodmanManager:
             self.results.update({'diff': self.container.diff})
         if self.module.params['debug'] or self.module_params['debug']:
             self.results.update({'podman_version': self.container.version})
-        self.results.update(
-            {'podman_systemd': generate_systemd(self.module,
-                                                self.module_params,
-                                                self.name,
-                                                self.container.version)})
+        self.results.update({'podman_systemd': self.container.systemd_unit})
 
     def make_started(self):
         """Run actions if desired state is 'started'."""


### PR DESCRIPTION
Start and stop containers with `systemctl` instead of `podman` when a user is generating the systemd unit for the container.

This prevents an annoying behavior that occurs with the following example task:

```yaml
---
- name: Create an Authentik container
  containers.podman.podman_container:
    name: authentik
    image: "{{ authentik_container_image }}:{{ authentik_container_tag }}"
    image_strict: yes
    state: started
    command: server
    generate_systemd:
      path: /etc/systemd/system/
      restart_policy: always
      time: 120
      new: true
      requires:
        - postgresql.service
        - redis.service
      after:
        - postgresql.service
        - redis.service
    env_file: /etc/default/container-authentik
    volume:
      - /srv/containers/authentik/blueprints:/blueprints/aethernet
    restart_policy: "no" # letting systemd handle this
```

This example task works perfectly fine when creating the container, but if want to update the tag it misbehaves. The resulting container, at the end of the run, is not updated. This is because of the following sequence of events:

1. The `containers.podman.podman_container` module (here on, "ansible") queries podman for the running container information. Determines the image needs to be changed.
2. It will then attempt to recreate the container. Since podman doesn't have a native way to do this, it does that by stopping and then deleting the container. So, ansible will run `podman stop`.
3. The container stops, and systemd notices this, so it thinks the unit has failed and will restart the unit. **NB: At this point, the unit is still configured with the old image.**
4. The container is deleted by ansible (because ansible ran `podman rm` as well) and then recreated with the updated configuration. Ansible thinks everything is good, so it continues on.
5. systemd again notices the unit (`container-authentik` in this example) has "failed", and will recreate it.
6. At the end of the module's execution, ansible will call `podman generate systemd` but that scans the *running container*, which was constantly being remade by systemd and is not the latest tag. So this step effectively becomes a no-op.
7. All of the commands and file manipulation have succeeded, so ansible thinks the module has succeeded. All good?

Sometimes, steps 3 & 4 above are swapped, in which case the module does fail because it attempts to create a container with a name that already exists, and podman (correctly) complains.

This is all due to the fact that this module is attempting to stop & start containers directly when I've configured them to be managed by a different service management daemon (systemd). Since we're already systemd-aware, it makes sense to me to teach the module how to properly behave in that scenario.