### PR TITLE
CI: fix pip installation of the collection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr'],
-    pbr=True)
+    pbr=True,
+    py_modules=[])


### PR DESCRIPTION
https://github.com/pypa/setuptools/issues/3197
latest release of setuptools 61.0 broke pip install