### PR TITLE
Fix idempotency checks when using `userns`

### DIFF
--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -511,7 +511,7 @@ class PodmanPodDiff:
             # TODO: find out why on Ubuntu the 'net' is not present
             if 'net' not in before:
                 after.remove('net')
-        if self.params["uidmap"] or self.params["gidmap"]:
+        if self.params["uidmap"] or self.params["gidmap"] or self.params["userns"]:
             after.append('user')
 
         before, after = sorted(list(set(before))), sorted(list(set(after)))

--- a/tests/integration/targets/podman_pod/tasks/main.yml
+++ b/tests/integration/targets/podman_pod/tasks/main.yml
@@ -333,7 +333,7 @@
         that:
           - pod15_a_info is changed
 
-    - name: Start pod with share for idempotency
+    - name: Start pod with gidmap and uidmap for idempotency
       containers.podman.podman_pod:
         executable: "{{ test_executable | default('podman') }}"
         name: pod1
@@ -346,6 +346,47 @@
       assert:
         that:
           - pod15_b_info is not changed
+
+    # Reset the namespace check.
+    # This is because changing from `uidmap/gidmap` to `userns` does not
+    # report a difference currently
+    - name: Start pod without uidmap to reset
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: created
+      register: pod15_c_info
+
+    - name: Check info
+      assert:
+        that:
+          - pod15_c_info is changed
+
+    - name: Start pod with userns
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        userns: auto
+        state: created
+      register: pod_userns_a_info
+
+    - name: Check info
+      assert:
+        that:
+          - pod_userns_a_info is changed
+
+    - name: Start pod with userns for idempotency
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        userns: auto
+        state: created
+      register: pod_userns_b_info
+
+    - name: Check info
+      assert:
+        that:
+          - pod_userns_b_info is not changed
 
     - name: Start pod with labels
       containers.podman.podman_pod:


### PR DESCRIPTION
Previously, this would only mark the userns as expected when `uidmap` or `gidmap` is passed. However, in the case `userns` is passed, this is also expected to be set.