### PR TITLE
Add support for health-on-failure action

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -67,6 +67,8 @@ ARGUMENTS_SPEC_CONTAINER = dict(
     healthcheck_retries=dict(type='int'),
     healthcheck_start_period=dict(type='str'),
     healthcheck_timeout=dict(type='str'),
+    healthcheck_failure_action=dict(type='str', choices=[
+        'none', 'kill', 'restart', 'stop']),
     hooks_dir=dict(type='list', elements='str'),
     hostname=dict(type='str'),
     http_proxy=dict(type='bool'),
@@ -410,6 +412,10 @@ class PodmanModuleParams:
     def addparam_healthcheck_timeout(self, c):
         return c + ['--healthcheck-timeout',
                     self.params['healthcheck_timeout']]
+
+    def addparam_healthcheck_failure_action(self, c):
+        return c + ['--health-on-failure',
+                    self.params['healthcheck_failure_action']]
 
     def addparam_hooks_dir(self, c):
         for hook_dir in self.params['hooks_dir']:
@@ -951,6 +957,14 @@ class PodmanContainerDiff:
                 before = self.info['config']['healthcheck']['test'][1]
         after = self.params['healthcheck'] or before
         return self._diff_update_and_compare('healthcheck', before, after)
+
+    def diffparam_healthcheck_failure_action(self):
+        if 'healthcheckonfailureaction' in self.info['config']:
+            before = self.info['config']['healthcheckonfailureaction']
+        else:
+            before = ''
+        after = self.params['healthcheck_failure_action'] or before
+        return self._diff_update_and_compare('healthcheckonfailureaction', before, after)
 
     # Because of hostname is random generated, this parameter has partial idempotency only.
     def diffparam_hostname(self):

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -436,6 +436,17 @@ options:
         is considered failed. Like start-period, the value can be expressed in
         a time format such as 1m22s. The default value is 30s
     type: str
+  healthcheck_failure_action:
+    description:
+      - The action to be taken when the container is considered unhealthy. The action must be one of
+            "none", "kill", "restart", or "stop".
+            The default policy is "none".
+    type: str
+    choices:
+      - 'none'
+      - 'kill'
+      - 'restart'
+      - 'stop'
   hooks_dir:
     description:
       - Each .json file in the path configures a hook for Podman containers.


### PR DESCRIPTION
This adds the new parameter `healthcheck_failure_action`, which maps into the podman argument `--health-on-failure`. As explained in the [podman docs](https://docs.podman.io/en/latest/markdown/podman-run.1.html#health-on-failure-action):

> **--health-on-failure=action**
> Action to take once the container transitions to an unhealthy state. The default is none.
> 
> none: Take no action.
> 
> kill: Kill the container.
> 
> restart: Restart the container. Do not combine the restart action with the --restart flag. When running inside of a systemd unit, consider using the kill or stop action instead to make use of systemd’s restart policy.
> 
> stop: Stop the container.
> 

This argument is useful to be combined with the existing ones in the current [podman_container](https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_module.html#parameter-healthcheck) Ansible module because it determines what should happen with the container when it becomes unhealthy.

After testing the new parameter locally, my container shows the `--health-on-failure` argument correctly:

```bash
[podman@bbd-rhel8 ~]$ podman inspect --format="{{.Config.CreateCommand}}" nginx
[podman container create --name nginx --hostname nginx --restart=on-failure --network nginx-network --ipc shareable --blkio-weight 100 --cpu-shares 2 --memory 524288000 --memory-swap 524288000 --healthcheck-command /etc/nginx/healthcheck.sh --healthcheck-interval 30s --healthcheck-retries 1 --healthcheck-start-period 10s --healthcheck-timeout 30s --health-on-failure restart --publish 80:80 --publish 443:443 --volume /home/podman/.podman/nginx/nginx.conf:/etc/nginx/nginx.conf:ro --volume /home/podman/.podman/nginx/conf.d/:/etc/nginx/conf.d/:ro --volume /home/podman/.podman/nginx/ssl/:/etc/nginx/ssl/:ro --volume /home/podman/.podman/nginx/ssl/:/etc/bbd/ssl/:ro --volume /home/podman/.podman/nginx/healthcheck.sh:/etc/nginx/healthcheck.sh:ro nginx:stable]
```

Fixes: #653