### PR TITLE
Recreate stopped containers if `recreate` flag is enabled

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1654,7 +1654,8 @@ class PodmanManager:
             self.results['actions'].append('started %s' % self.container.name)
             self.update_container_result()
             return
-        elif self.container.stopped and self.container.different:
+        elif self.container.stopped and \
+                (self.container.different or self.recreate):
             self.container.recreate_run()
             self.results['actions'].append('recreated %s' %
                                            self.container.name)

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -235,6 +235,26 @@
         fail_msg: "Creating stopped container test failed!"
         success_msg: "Creating stopped container test passed!"
 
+    - name: Force recreate stopped container
+      containers.podman.podman_container:
+        executable: "{{ test_executable | default('podman') }}"
+        name: container
+        image: alpine:3.7
+        state: started
+        command: sleep 1d
+        recreate: true
+      register: recreate_stopped
+
+    - name: Check output is correct
+      assert:
+        that:
+          - recreate_stopped is changed
+          - recreate_stopped.container is defined
+          - recreate_stopped.container['State']['Running']|bool
+          - "'recreated container' in recreate_stopped.actions"
+        fail_msg: Force recreate stopped test failed!
+        success_msg: Force recreate stopped test passed!
+
     - name: Delete created container
       containers.podman.podman_container:
         executable: "{{ test_executable | default('podman') }}"


### PR DESCRIPTION
If `recreate` flag is enabled we should be able to recreate stopped containers even if their configuration aren't changed.

This become important if those containers has bind mounted files that are recreated from scratch instead of being edited (for example files managed by ansible or puppet)