### PR TITLE
Alias generate systemd options `stop_timeout` and `time`

### DIFF
--- a/plugins/module_utils/podman/common.py
+++ b/plugins/module_utils/podman/common.py
@@ -52,12 +52,14 @@ def run_generate_systemd_command(module, module_params, name, version):
             sysconf['restart_policy']])
     if sysconf.get('restart_sec') is not None:
         command.extend(['--restart-sec=%s' % sysconf['restart_sec']])
-    if sysconf.get('stop_timeout') is not None:
-        command.extend(['--stop-timeout=%s' % sysconf['stop_timeout']])
+    if sysconf.get('stop_timeout') is not None or sysconf.get('time') is not None:
+        # Select correct parameter name based on version
+        arg_name = 'stop_timeout' if gt4ver else 'time'
+        arg_value = sysconf.get('stop_timeout') if sysconf.get('stop_timeout') is not None else sysconf.get('time')
+        command.extend(['--%s=%s' % (arg_name, arg_value)])
+        del arg_name, arg_value
     if sysconf.get('start_timeout') is not None:
         command.extend(['--start-timeout=%s' % sysconf['start_timeout']])
-    if sysconf.get('time'):
-        command.extend(['--time', str(sysconf['time'])])
     if sysconf.get('no_header'):
         command.extend(['--no-header'])
     if sysconf.get('names', True):

--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -336,14 +336,12 @@ options:
         type: int
         required: false
       stop_timeout:
-        description: Override the default stop timeout for the container with the given value.
-        type: int
-        required: false
-      time:
         description:
-          - Override the default stop timeout for the container with the given value.
+          - Override the default stop timeout for the container with the given value. Called `time` before version 4.
         type: int
         required: false
+        aliases:
+          - time
       no_header:
         description:
           - Do not generate the header including meta data such as the Podman version and the timestamp.
@@ -891,7 +889,7 @@ EXAMPLES = r"""
     generate_systemd:
       path: /tmp/
       restart_policy: always
-      time: 120
+      stop_timeout: 120
       names: true
       container_prefix: ainer
 

--- a/plugins/modules/podman_pod.py
+++ b/plugins/modules/podman_pod.py
@@ -160,14 +160,12 @@ options:
         type: int
         required: false
       stop_timeout:
-        description: Override the default stop timeout for the container with the given value.
-        type: int
-        required: false
-      time:
         description:
-          - Override the default stop timeout for the container with the given value.
+          - Override the default stop timeout for the container with the given value. Called `time` before version 4.
         type: int
         required: false
+        aliases:
+          - time
       no_header:
         description:
           - Do not generate the header including meta data such as the Podman version and the timestamp.


### PR DESCRIPTION
Closes #683

The spec of the `podman generate systemd` command has changed between v3 and v4.
Option `time` was used before Podman v4 ([manpage](https://docs.podman.io/en/v3.4.4/markdown/podman-generate-systemd.1.html)), then it has been renamed `stop_timeout` ([manpage](https://docs.podman.io/en/v4.0.0/markdown/podman-generate-systemd.1.html)).
Problems with this change have also been reported in #675.

The proposed change is to accept both names (the newer takes prirority) and set the correct CLI argument name based on the detected Podman version.
In this way, the user doesn't have to implement a different behavior based on the detected Podman version.

The change involves modules `podman_container` and `podman_pod`.