### PR TITLE
Add option to parse CreateCommand easily for diff calc

### DIFF
--- a/plugins/module_utils/podman/common.py
+++ b/plugins/module_utils/podman/common.py
@@ -19,6 +19,25 @@ except ImportError:
                                ' < 2.11, you need to use Python < 3.12 with '
                                'distutils.version present'), exc)
 
+ARGUMENTS_OPTS_DICT = {
+    '--attach': ['--attach', '-a'],
+    '--cpu-shares': ['--cpu-shares', '-c'],
+    '--detach': ['--detach', '-d'],
+    '--env': ['--env', '-e'],
+    '--hostname': ['--hostname', '-h'],
+    '--interactive': ['--interactive', '-i'],
+    '--label': ['--label', '-l'],
+    '--memory': ['--memory', '-m'],
+    '--network': ['--network', '--net'],
+    '--publish': ['--publish', '-p'],
+    '--publish-all': ['--publish-all', '-P'],
+    '--quiet': ['--quiet', '-q'],
+    '--tty': ['--tty', '-t'],
+    '--user': ['--user', '-u'],
+    '--volume': ['--volume', '-v'],
+    '--workdir': ['--workdir', '-w'],
+}
+
 
 def run_podman_command(module, executable='podman', args=None, expected_rc=0, ignore_errors=False):
     if not isinstance(executable, list):


### PR DESCRIPTION
We have a few calculations of given options and arguments from CreateCommand, so let's do it in a more convinient way. Define a function _createcommand which receives an argument and returns all values for it in a command line of Podman.
Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>