### PR TITLE
Fix idempotency for podman_network

### DIFF
--- a/plugins/modules/podman_network.py
+++ b/plugins/modules/podman_network.py
@@ -348,11 +348,7 @@ class PodmanNetworkDiff:
     def diffparam_disable_dns(self):
         # For v3 it's impossible to find out DNS settings.
         if LooseVersion(self.version) >= LooseVersion('4.0.0'):
-            if self.info.get('driver') == 'bridge':
-                before = not self.info.get('dns_enabled', True)
-            # for all other drivers except bridge DNS is disabled by default
-            else:
-                before = False
+            before = not self.info.get('dns_enabled', True)
             after = self.params['disable_dns']
             # compare only if set explicitly
             if self.params['disable_dns'] is None:


### PR DESCRIPTION
This pull requests fixes a bug in the diff function (`diffparam_disable_dns`) for the parameter in the `podman_network` plugin (see #699).
It fixes the idempotency for `podman_network` when explicitly definining `disable_dns` parameter for Podman driver other than type `bridge`.

The problem was introduced in #650 (relating issue #647).