### PR TITLE
Ensure container start command has the attach flag

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1501,6 +1501,9 @@ class PodmanContainer:
                                        ).construct_command_from_params()
         if action == 'create':
             b_command.remove(b'--detach=True')
+
+        if action == 'start' and not self.module_params['detach']:
+            b_command.append(b'--attach')
         full_cmd = " ".join([self.module_params['executable']]
                             + [to_native(i) for i in b_command])
         self.actions.append(full_cmd)


### PR DESCRIPTION
When starting an already created (not running) container detach=False is not honored. This results container failures not being reported as failure.