### PR TITLE
Fix broken example for podman_generate_systemd

### DIFF
--- a/plugins/modules/podman_generate_systemd.py
+++ b/plugins/modules/podman_generate_systemd.py
@@ -183,6 +183,7 @@ EXAMPLES = '''
 - name: Postgres container must be started and enabled on systemd
   ansible.builtin.systemd:
     name: container-postgres_local
+    scope: user
     daemon_reload: true
     state: started
     enabled: true


### PR DESCRIPTION
Change the postgres_local example to use the scope of "user" so the unit file saved to ~/.config/systemd/user/ will be used by systemd.