### PR TITLE
podman pod info: handle return being list in Podman 5

### DIFF
--- a/plugins/module_utils/podman/podman_pod_lib.py
+++ b/plugins/module_utils/podman/podman_pod_lib.py
@@ -658,7 +658,16 @@ class PodmanPod:
         # pylint: disable=unused-variable
         rc, out, err = self.module.run_command(
             [self.module_params['executable'], b'pod', b'inspect', self.name])
-        return json.loads(out) if rc == 0 else {}
+        if rc == 0:
+            info = json.loads(out)
+            # from podman 5 onwards, this is a list of dicts,
+            # before it was just a single dict when querying
+            # a single pod
+            if isinstance(info, list):
+                return info[0]
+            else:
+                return info
+        return {}
 
     def get_ps(self):
         """Inspect pod process and gather info about it."""


### PR DESCRIPTION
Fixes #712

Podman 5 changed the output of `podman pod info` (when run on a single pod) from being a dict to being a list of dicts:

https://github.com/containers/podman/pull/21514

this should handle both ways. Unfortunately not sure how to add a test for this as I can't see a unit test that mocks the output of the command, only the integration test that gets real live output, and I'm not sure how to get that test run with Podman 5.