### PR TITLE
Remove unnecessary quotes in podman_container_exec module

### DIFF
--- a/plugins/modules/podman_container_exec.py
+++ b/plugins/modules/podman_container_exec.py
@@ -162,7 +162,7 @@ def run_container_exec(module: AnsibleModule) -> dict:
 
             to_text(value, errors='surrogate_or_strict')
             exec_options += ['--env',
-                             '%s="%s"' % (key, value)]
+                             '%s=%s' % (key, value)]
 
     if privileged:
         exec_options.append('--privileged')


### PR DESCRIPTION
Fix #714
Seems like shell is handling this fine without quotes.
Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>
