### PR TITLE
Update podman_login.py

### DIFF
--- a/plugins/modules/podman_login.py
+++ b/plugins/modules/podman_login.py
@@ -154,10 +154,7 @@ def main():
         supports_check_mode=True,
         required_together=(
             ['username', 'password'],
-        ),
-        mutually_exclusive=(
-            ['certdir', 'tlsverify'],
-        ),
+        )
     )
 
     registry = module.params['registry']


### PR DESCRIPTION
Make tlsverify and certdir parameters no longer mutually exclusive. Resolves https://github.com/containers/ansible-podman-collections/issues/723