### PR TITLE
Update the logic for deleting pods/containers in podman_play

### DIFF
--- a/tests/integration/targets/podman_play/tasks/main.yml
+++ b/tests/integration/targets/podman_play/tasks/main.yml
@@ -107,6 +107,34 @@
         that:
           - info1['pods'][0]['State'] == 'Running'
 
+    - name: Remove pods created by kube play
+      containers.podman.podman_play:
+        executable: "{{ test_executable | default('podman') }}"
+        kube_file: "{{ item }}"
+        state: absent
+      register: remove_pod
+      loop:
+        - /tmp/play1.yaml
+        - /tmp/play3.yaml
+
+    - name: Get deleted pod info
+      containers.podman.podman_pod_info:
+        executable: "{{ test_executable | default('podman') }}"
+        name: "{{ item }}"
+      loop:
+        - web-deploy
+        - web-deploy-pod
+        - web-deploy-pod-0
+        - web-deploy-pod-1
+        - web-deploy-pod-2
+      register: nonexist
+
+    - name: Check if the result is as expected
+      assert:
+        that:
+          - item.pods == []
+      with_items: "{{ nonexist.results }}"
+
   always:
 
     - name: Delete all pods leftovers from tests

--- a/tests/integration/targets/podman_play/tasks/main.yml
+++ b/tests/integration/targets/podman_play/tasks/main.yml
@@ -110,31 +110,26 @@
     - name: Remove pods created by kube play
       containers.podman.podman_play:
         executable: "{{ test_executable | default('podman') }}"
-        kube_file: "{{ item }}"
+        kube_file: /tmp/play3.yaml
         state: absent
       register: remove_pod
-      loop:
-        - /tmp/play1.yaml
-        - /tmp/play3.yaml
 
+    - name: Check if the pod was removed as expected
+      assert:
+        that:
+          - remove_pod is changed
+          
     - name: Get deleted pod info
       containers.podman.podman_pod_info:
         executable: "{{ test_executable | default('podman') }}"
-        name: "{{ item }}"
-      loop:
-        - web-deploy
-        - web-deploy-pod
-        - web-deploy-pod-0
-        - web-deploy-pod-1
-        - web-deploy-pod-2
+        name: web-deploy-pod
       register: nonexist
 
     - name: Check if the result is as expected
       assert:
         that:
-          - item.pods == []
-      with_items: "{{ nonexist.results }}"
-
+          - nonexist.pods == []
+  
   always:
 
     - name: Delete all pods leftovers from tests


### PR DESCRIPTION
As discussed [here](https://github.com/containers/ansible-podman-collections/pull/724#discussion_r1535719450), this PR improves the logic for deleting pods/containers in podman_play, more specifically updates`remove_associated_pods` and uses `podman kube play --down` instead. 