### PR TITLE
Fix pod info for non-existant pods

### DIFF
--- a/plugins/modules/podman_pod_info.py
+++ b/plugins/modules/podman_pod_info.py
@@ -109,7 +109,7 @@ def get_pod_info(module, executable, name):
         rc, out, err = module.run_command(command + [pod])
         errs.append(err.strip())
         rcs += [rc]
-        data = json.loads(out)
+        data = json.loads(out) if out else None
         if isinstance(data, list) and data:
             data = data[0]
         if not out or data is None or not data:


### PR DESCRIPTION
Do not try to deserialize json when out is empty

Fixes #731