### PR TITLE
Fix issue with pushing podman image to repo name and org

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -797,6 +797,9 @@ class PodmanImageManager(object):
             dest_string = dest_format_string.format(transport=transport, name=self.name, dest=dest)
         else:
             dest_string = dest
+            # In case of dest as a repository with org name only, append image name to it
+            if ":" not in dest and "@" not in dest and len(dest.rstrip("/").split("/")) == 2:
+                dest_string = dest.rstrip("/") + "/" + self.image_name
 
         if "/" not in dest_string and "@" not in dest_string and "docker-daemon" not in dest_string:
             self.module.fail_json(msg="Destination must be a full URL or path to a directory.")

--- a/tests/integration/targets/podman_image/tasks/idem_push.yml
+++ b/tests/integration/targets/podman_image/tasks/idem_push.yml
@@ -101,6 +101,52 @@
 
 - containers.podman.podman_image:
     name: testimage2
+    tag: testtag
+    pull: false
+    push: true
+    push_args:
+      dest: quay.io/testing
+  ignore_errors: true
+  register: img_result4a
+
+- name: Check outputs
+  assert:
+    that:
+      - "'authentication required' in img_result4a.stderr"
+      - "'push testimage2:testtag quay.io/testing/testimage2:testtag' in img_result4a.actions"
+
+- containers.podman.podman_image:
+    name: testimage2:testtag
+    pull: false
+    push: true
+    push_args:
+      dest: quay.io/testing/
+  ignore_errors: true
+  register: img_result4b
+
+- name: Check outputs
+  assert:
+    that:
+      - "'authentication required' in img_result4b.stderr"
+      - "'push testimage2:testtag quay.io/testing/testimage2:testtag' in img_result4b.actions"
+
+- containers.podman.podman_image:
+    name: testimage2
+    pull: false
+    push: true
+    push_args:
+      dest: quay.io/testing/
+  ignore_errors: true
+  register: img_result4c
+
+- name: Check outputs
+  assert:
+    that:
+      - "'authentication required' in img_result4c.stderr"
+      - "'push testimage2:latest quay.io/testing/testimage2:latest' in img_result4c.actions"
+
+- containers.podman.podman_image:
+    name: testimage2
     pull: false
     push: true
     push_args:


### PR DESCRIPTION
If destination doesn't have image, but only repo name and org, complete with image name and tag.