### PR TITLE
Fix missing entries in network quadlet generated file (#792)

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -386,8 +386,8 @@ class NetworkQuadlet(Quadlet):
         "opt": "Options",
         # Add more parameter mappings specific to networks
         'ContainersConfModule': 'ContainersConfModule',
-        "DNS": "DNS",
-        "IPAMDriver": "IPAMDriver",
+        "dns": "DNS",
+        "ipam_driver": "IPAMDriver",
         "Label": "Label",
         "global_args": "GlobalArgs",
         "podman_args": "PodmanArgs",


### PR DESCRIPTION
Align the keys in the NetworkQuadlet param_map to match the keys in the documentation.