### PR TITLE
fix for tls_verify being ignored

### DIFF
--- a/plugins/module_utils/podman/podman_container_lib.py
+++ b/plugins/module_utils/podman/podman_container_lib.py
@@ -1529,10 +1529,14 @@ def ensure_image_exists(module, image, module_params):
         return image_actions
     if not image:
         return image_actions
-    rc, out, err = module.run_command([module_exec, 'image', 'exists', image])
+    image_exists_cmd = [module_exec, 'image', 'exists', image]
+    rc, out, err = module.run_command(image_exists_cmd)
     if rc == 0:
         return image_actions
-    rc, out, err = module.run_command([module_exec, 'image', 'pull', image])
+    image_pull_cmd = [module_exec, 'image', 'pull', image]
+    if module_params['tls_verify'] is False:
+        image_pull_cmd.append('--tls-verify=false')
+    rc, out, err = module.run_command(image_pull_cmd)
     if rc != 0:
         module.fail_json(msg="Can't pull image %s" % image, stdout=out,
                          stderr=err)

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -108,6 +108,53 @@
         fail_msg: Pulling image test failed!
         success_msg: Pulling image test passed!
 
+    - name: Ensure image doesn't exist - TLS verify OFF
+      containers.podman.podman_image:
+        executable: "{{ test_executable | default('podman') }}"
+        name: alpine:3.20
+        state: absent
+
+    - name: Check pulling image - TLS verify OFF
+      containers.podman.podman_container:
+        executable: "{{ test_executable | default('podman') }}"
+        name: container_tls
+        image: alpine:3.20
+        state: started
+        command: sleep 1d
+        tls_verify: false
+      register: image_tls
+
+    - name: Check output is correct - TLS verify OFF
+      assert:
+        that:
+          - image_tls.podman_actions | select('search', '--tls-verify=False') | list | length > 0
+
+    - name: Check using already pulled image - TLS verify OFF
+      containers.podman.podman_container:
+        executable: "{{ test_executable | default('podman') }}"
+        name: container2_tls
+        image: alpine:3.20
+        state: started
+        command: sleep 1d
+        tls_verify: false
+      register: image2_tls
+
+    - name: Check output is correct - TLS verify OFF
+      assert:
+        that:
+          - image_tls is changed
+          - image_tls.container is defined
+          - image_tls.container['State']['Running']
+          - "'pulled image alpine:3.20' in image_tls.actions"
+          - "'started container_tls' in image_tls.actions"
+          - image2_tls is changed
+          - image2_tls.container is defined
+          - image2_tls.container['State']['Running']
+          - "'pulled image alpine:3.20' not in image2_tls.actions"
+          - "'started container2_tls' in image2_tls.actions"
+        fail_msg: Pulling image test failed!
+        success_msg: Pulling image test passed!
+
     - name: Check failed image pull
       containers.podman.podman_container:
         executable: "{{ test_executable | default('podman') }}"
@@ -1368,6 +1415,7 @@
         - "container2"
         - "container3"
         - "testidem-pod"
+        - "container_tls"
 
     - name: Remove pod
       shell: podman pod rm -f testidempod


### PR DESCRIPTION
Provides a fix for "ensure_image_exists" function in _**podman_container_lib.py**_ to consider tls_verify parameter when it is false.
If the parameter is not specified, it doesn't affect the execution (it is enabled by default in podman image pull command).

Fixes #810 