### PR TITLE
Add group_add parameter for podman quadlet

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -253,7 +253,7 @@ class ContainerQuadlet(Quadlet):
             params["podman_args"].append(f"--gpus {params['gpus']}")
         if params["group_add"]:
             for group in params["group_add"]:
-                params["podman_args"].append(f"--group_add {group}")
+                params["podman_args"].append(f"--group-add {group}")
         if params["group_entry"]:
             params["podman_args"].append(f"--group-entry {params['group_entry']}")
         if params["hostuser"]:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -251,6 +251,9 @@ class ContainerQuadlet(Quadlet):
                 params["podman_args"].append(f"--env {k}={v}")
         if params["gpus"]:
             params["podman_args"].append(f"--gpus {params['gpus']}")
+        if params["group_add"]:
+            for group in params["group_add"]:
+                params["podman_args"].append(f"--group_add {group}")
         if params["group_entry"]:
             params["podman_args"].append(f"--group-entry {params['group_entry']}")
         if params["hostuser"]:


### PR DESCRIPTION
The group_add parameter is not propagated to the container file at the moment.

This pull request adds the feature. 