### PR TITLE
fix(podman_image): skip empty volume items

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -701,7 +701,8 @@ class PodmanImageManager(object):
         volume = self.build.get('volume')
         if volume:
             for v in volume:
-                args.extend(['--volume', v])
+                if v:
+                    args.extend(['--volume', v])
 
         if self.auth_file:
             args.extend(['--authfile', self.auth_file])


### PR DESCRIPTION
Skip empty volume items with `podman image build`:

```yaml
- containers.podman.podman_image:
    name: myimage
    path: /tmp/myimage
    build:
      volume:
        - "{{ '/tmp/whatever:/mnt/whatever' if false }}" # results in "" (empty string), which leads to podman error
    state: build
```

This PR adds a check in `podman_image` module, just like it is already done over here: https://github.com/containers/ansible-podman-collections/blob/master/plugins/module_utils/podman/podman_container_lib.py#L859-L863