### PR TITLE
Fix quadlet parameters when container uses rootfs

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -166,6 +166,9 @@ class ContainerQuadlet(Quadlet):
             params["label"] = ["%s=%s" % (k, v) for k, v in params["label"].items()]
         if params["env"]:
             params["env"] = ["%s=%s" % (k, v) for k, v in params["env"].items()]
+        if params["rootfs"]:
+            params["rootfs"] = params["image"]
+            params["image"] = None
         if params["sysctl"]:
             params["sysctl"] = ["%s=%s" % (k, v) for k, v in params["sysctl"].items()]
         if params["tmpfs"]:


### PR DESCRIPTION
Adjust quadlet parameters to set rootfs as image and clear image field when rootfs container is being used.

e.g.:
```
  containers.podman.podman_container:
    rootfs: true
    image: "/opt/container-root"
```

should put into a quadlet file (note, no `Image=` in a file):
```
Rootfs=/opt/container-root
```
