### PR TITLE
Add missing parameters for podman container quadlet

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -108,6 +108,7 @@ class ContainerQuadlet(Quadlet):
         'ip6': 'IP6',
         'label': 'Label',
         'log_driver': 'LogDriver',
+        'log_opt': 'LogOpt',
         "Mask": "Mask",  # add it in security_opt
         'mount': 'Mount',
         'network': 'Network',
@@ -284,8 +285,7 @@ class ContainerQuadlet(Quadlet):
         if params["label_file"]:
             params["podman_args"].append(f"--label-file {params['label_file']}")
         if params["log_opt"]:
-            for k, v in params['log_opt'].items():
-                params["podman_args"].append(f"--log-opt {k.replace('max_size', 'max-size')}={v}")
+            params["log_opt"] = ["%s=%s" % (k.replace('max_size', 'max-size'), v) for k, v in params['log_opt'].items()]
         if params["mac_address"]:
             params["podman_args"].append(f"--mac-address {params['mac_address']}")
         if params["memory"]:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -254,9 +254,6 @@ class ContainerQuadlet(Quadlet):
                 params["podman_args"].append(f"--env {k}={v}")
         if params["gpus"]:
             params["podman_args"].append(f"--gpus {params['gpus']}")
-        if params["group_add"]:
-            for group in params["group_add"]:
-                params["podman_args"].append(f"--group-add {group}")
         if params["group_entry"]:
             params["podman_args"].append(f"--group-entry {params['group_entry']}")
         if params["hostuser"]:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -84,6 +84,7 @@ class ContainerQuadlet(Quadlet):
         'env': 'Environment',
         'env_file': 'EnvironmentFile',
         'env_host': 'EnvironmentHost',
+        'etc_hosts': 'AddHost',
         'command': 'Exec',
         'expose': 'ExposeHostPort',
         'gidmap': 'GIDMap',
@@ -249,8 +250,7 @@ class ContainerQuadlet(Quadlet):
             for i in params["device_write_iops"]:
                 params["podman_args"].append(f"--device-write-iops {i}")
         if params["etc_hosts"]:
-            for host_ip in params['etc_hosts'].items():
-                params["podman_args"].append(f"--add-host {':'.join(host_ip)}")
+            params['etc_hosts'] = ["%s:%s" % (k, v) for k, v in params['etc_hosts'].items()]
         if params["env_merge"]:
             for k, v in params["env_merge"].items():
                 params["podman_args"].append(f"--env {k}={v}")

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -221,6 +221,8 @@ class ContainerQuadlet(Quadlet):
             params["podman_args"].append(f"--cidfile {params['cidfile']}")
         if params["conmon_pidfile"]:
             params["podman_args"].append(f"--conmon-pidfile {params['conmon_pidfile']}")
+        if params['cpus']:
+            params["podman_args"].append(f"--cpus {params['cpus']}")
         if params["cpuset_cpus"]:
             params["podman_args"].append(f"--cpuset-cpus {params['cpuset_cpus']}")
         if params["cpuset_mems"]:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -131,6 +131,7 @@ class ContainerQuadlet(Quadlet):
         'SecurityLabelNested': 'SecurityLabelNested',
         'SecurityLabelType': 'SecurityLabelType',
         'shm_size': 'ShmSize',
+        'stop_signal': 'StopSignal',
         'stop_timeout': 'StopTimeout',
         'subgidname': 'SubGIDMap',
         'subuidname': 'SubUIDMap',
@@ -345,8 +346,6 @@ class ContainerQuadlet(Quadlet):
             params["podman_args"].append(f"--shm-size-systemd {params['shm_size_systemd']}")
         if params["sig_proxy"]:
             params["podman_args"].append(f"--sig-proxy {params['sig_proxy']}")
-        if params["stop_signal"]:
-            params["podman_args"].append(f"--stop-signal {params['stop_signal']}")
         if params["systemd"]:
             params["podman_args"].append(f"--systemd={str(params['systemd']).lower()}")
         if params["timeout"]:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -79,6 +79,7 @@ class ContainerQuadlet(Quadlet):
         'dns_option': 'DNSOption',
         'dns_search': 'DNSSearch',
         'cap_drop': 'DropCapability',
+        'cgroups': 'CgroupsMode',
         'entrypoint': 'Entrypoint',
         'env': 'Environment',
         'env_file': 'EnvironmentFile',

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -111,6 +111,7 @@ class ContainerQuadlet(Quadlet):
         "Mask": "Mask",  # add it in security_opt
         'mount': 'Mount',
         'network': 'Network',
+        'network_aliases': 'NetworkAlias',
         'no_new_privileges': 'NoNewPrivileges',
         'sdnotify': 'Notify',
         'pids_limit': 'PidsLimit',
@@ -292,9 +293,6 @@ class ContainerQuadlet(Quadlet):
             params["podman_args"].append(f"--memory-swap {params['memory_swap']}")
         if params["memory_swappiness"]:
             params["podman_args"].append(f"--memory-swappiness {params['memory_swappiness']}")
-        if params["network_aliases"]:
-            for alias in params["network_aliases"]:
-                params["podman_args"].append(f"--network-alias {alias}")
         if params["no_healthcheck"]:
             params["podman_args"].append("--no-healthcheck")
         if params["no_hosts"] is not None:

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -316,6 +316,8 @@ class ContainerQuadlet(Quadlet):
             params["podman_args"].append(f"--pid {params['pid']}")
         if params["pid_file"]:
             params["podman_args"].append(f"--pid-file {params['pid_file']}")
+        if params['platform']:
+            params["podman_args"].append(f"--platform {params['platform']}")
         if params["preserve_fd"]:
             for pres in params["preserve_fd"]:
                 params["podman_args"].append(f"--preserve-fd {pres}")

--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -88,6 +88,7 @@ class ContainerQuadlet(Quadlet):
         'gidmap': 'GIDMap',
         'global_args': 'GlobalArgs',
         'group': 'Group',  # Does not exist in module parameters
+        'group_add': 'GroupAdd',
         'healthcheck': 'HealthCmd',
         'healthcheck_interval': 'HealthInterval',
         'healthcheck_failure_action': 'HealthOnFailure',

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1275,7 +1275,7 @@
         - "SecurityLabelFileType=usr_t"
         - "Environment=BOOL=False"
         - "PublishPort=9001:8000"
-        - "PodmanArgs=--add-host host2:127.0.0.1"
+        - "AddHost=host2:127.0.0.1"
         - "Label=somelabel=labelvalue"
         - "WantedBy=default.target"
         - "GroupAdd=admin"

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1206,6 +1206,9 @@
         etc_hosts:
           host1: 127.0.0.1
           host2: 127.0.0.1
+        network_aliases:
+          - web
+          - db
         annotation:
           this: "annotation_value"
         dns:
@@ -1280,6 +1283,8 @@
         - "WantedBy=default.target"
         - "GroupAdd=admin"
         - "GroupAdd=users"
+        - "NetworkAlias=web"
+        - "NetworkAlias=db"
       loop_control:
         label: "{{ item }}"
 
@@ -1306,6 +1311,9 @@
         etc_hosts:
           host1: 127.0.0.1
           host2: 127.0.0.1
+        network_aliases:
+          - web
+          - db
         annotation:
           this: "annotation_value"
         dns:
@@ -1363,6 +1371,9 @@
         etc_hosts:
           host1: 127.0.0.45
           host2: 127.0.0.1
+        network_aliases:
+          - web
+          - db
         annotation:
           this: "annotation_value"
         dns:

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1200,6 +1200,9 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        group_add:
+          - admin
+          - users
         etc_hosts:
           host1: 127.0.0.1
           host2: 127.0.0.1
@@ -1273,6 +1276,8 @@
         - "PodmanArgs=--add-host host2:127.0.0.1"
         - "Label=somelabel=labelvalue"
         - "WantedBy=default.target"
+        - "GroupAdd=admin"
+        - "GroupAdd=users"
       loop_control:
         label: "{{ item }}"
 
@@ -1293,6 +1298,9 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        group_add:
+          - admin
+          - users
         etc_hosts:
           host1: 127.0.0.1
           host2: 127.0.0.1
@@ -1346,6 +1354,9 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        group_add:
+          - admin
+          - users
         etc_hosts:
           host1: 127.0.0.45
           host2: 127.0.0.1

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1211,6 +1211,7 @@
           - web
           - db
         cpus: 0.5
+        platform: linux/amd64
         annotation:
           this: "annotation_value"
         dns:
@@ -1289,6 +1290,7 @@
         - "NetworkAlias=db"
         - "StopSignal=9"
         - "PodmanArgs=--cpus 0.5"
+        - "PodmanArgs=--platform linux/amd64"
       loop_control:
         label: "{{ item }}"
 
@@ -1320,6 +1322,7 @@
           - web
           - db
         cpus: 0.5
+        platform: linux/amd64
         annotation:
           this: "annotation_value"
         dns:
@@ -1382,6 +1385,7 @@
           - web
           - db
         cpus: 0.5
+        platform: linux/amd64
         annotation:
           this: "annotation_value"
         dns:

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1233,6 +1233,10 @@
         label:
           somelabel: labelvalue
           otheralbe: othervalue
+        log_opt:
+          max_size: 10mb
+          path: /var/log/container/mycontainer.json
+          tag: TestTag
         volumes:
           - /tmp:/data
         cgroups: no-conmon
@@ -1291,6 +1295,9 @@
         - "StopSignal=9"
         - "PodmanArgs=--cpus 0.5"
         - "PodmanArgs=--platform linux/amd64"
+        - "LogOpt=max-size=10mb"
+        - "LogOpt=path=/var/log/container/mycontainer.json"
+        - "LogOpt=tag=TestTag"
       loop_control:
         label: "{{ item }}"
 
@@ -1344,6 +1351,10 @@
         label:
           somelabel: labelvalue
           otheralbe: othervalue
+        log_opt:
+          max_size: 10mb
+          path: /var/log/container/mycontainer.json
+          tag: TestTag
         volumes:
           - /tmp:/data
         cgroups: no-conmon
@@ -1407,6 +1418,10 @@
         label:
           somelabel: labelvalue
           otheralbe: othervalue
+        log_opt:
+          max_size: 10mb
+          path: /var/log/container/mycontainer.json
+          tag: TestTag
         volumes:
           - /tmp:/data
         cgroups: no-conmon

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1229,6 +1229,7 @@
           otheralbe: othervalue
         volumes:
           - /tmp:/data
+        cgroups: no-conmon
         mounts:
           - type=devpts,destination=/dev/pts
         quadlet_options:
@@ -1267,6 +1268,7 @@
         - "Image=alpine:3.12"
         - "Exec=sleep 1d"
         - "Volume=/tmp:/data"
+        - "CgroupsMode=no-conmon"
         - "Mount=type=devpts,destination=/dev/pts"
         - "WorkingDir=/bin"
         - "Unmask=ALL"
@@ -1327,6 +1329,7 @@
           otheralbe: othervalue
         volumes:
           - /tmp:/data
+        cgroups: no-conmon
         mounts:
           - type=devpts,destination=/dev/pts
         quadlet_options:
@@ -1383,6 +1386,7 @@
           otheralbe: othervalue
         volumes:
           - /tmp:/data
+        cgroups: no-conmon
         mounts:
           - type=devpts,destination=/dev/pts
         quadlet_options:

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1200,6 +1200,7 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        stop_signal: 9 #SIGKILL
         group_add:
           - admin
           - users
@@ -1285,6 +1286,7 @@
         - "GroupAdd=users"
         - "NetworkAlias=web"
         - "NetworkAlias=db"
+        - "StopSignal=9"
       loop_control:
         label: "{{ item }}"
 
@@ -1305,6 +1307,7 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        stop_signal: 9 #SIGKILL
         group_add:
           - admin
           - users
@@ -1365,6 +1368,7 @@
         quadlet_dir: /tmp
         command: sleep 1d
         recreate: true
+        stop_signal: 9 #SIGKILL
         group_add:
           - admin
           - users

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1210,6 +1210,7 @@
         network_aliases:
           - web
           - db
+        cpus: 0.5
         annotation:
           this: "annotation_value"
         dns:
@@ -1287,6 +1288,7 @@
         - "NetworkAlias=web"
         - "NetworkAlias=db"
         - "StopSignal=9"
+        - "PodmanArgs=--cpus 0.5"
       loop_control:
         label: "{{ item }}"
 
@@ -1317,6 +1319,7 @@
         network_aliases:
           - web
           - db
+        cpus: 0.5
         annotation:
           this: "annotation_value"
         dns:
@@ -1378,6 +1381,7 @@
         network_aliases:
           - web
           - db
+        cpus: 0.5
         annotation:
           this: "annotation_value"
         dns:


### PR DESCRIPTION
As noticed in #844 the group_add parameter should be mapped to GroupAdd in the .container file.
I noticed that several other parameters are missing or not mapped correctly.

Missing parameters that should be mapped (podman version that introduced them):
- [x] cgroups -> CgroupsMode (latest -> most probably v5.3.0)

Parameters that should be mapped to .container file syntax
- [x] etc\_hosts -> podman_args, should be AddHost (latest -> most probably v5.3.0)
- [x] log\_opt -> podman\_args, could be LogOpt (v5.2.0)
- [x] network\_aliases -> podman\_args, should be NetworkAlias (v5.2.0)
- [x] stop\_signal -> podman\_args, should be StopSignal (v5.2.0)
- [x] group_add -> podman\_args, should be GroupAdd (v5.1.0)

Parameters that should be mapped to podman\_args:
- [x] cpus
- [x] platform

There are also available parameters that can not be set using the collection but might be useful.
They are out of scope for this pull request, but some would be really useful such as AutoUpdate.
Here is a list for documentation:
- Autoupdate
- Mask
- SeccompProfile
- SecurityLabelDisable
- SecurityLabelFileType
- SecurityLabelLevel
- SecurityLabelNested
- SecurityLabelType
- Unmask

Resolves #844
This reverts commit 4f24eced99edfa0ec493cc1e5e356c23ccebeab3 from pull request #827 