### PR TITLE
don't document quadlet_dir as required when setting state=quadlet

### DIFF
--- a/plugins/modules/podman_container.py
+++ b/plugins/modules/podman_container.py
@@ -56,7 +56,6 @@ options:
         'created' state. If configuration doesn't match or 'recreate' option is
         set, the container will be recreated
       - I(quadlet) - Write a quadlet file with the specified configuration.
-        Requires the C(quadlet_dir) option to be set.
     type: str
     default: started
     choices:


### PR DESCRIPTION
The underlying code has sane defaults and will figure out the directory on its own in most cases
https://github.com/containers/ansible-podman-collections/blob/0b773e5d61d1f0c8ea33b8f42dafe2267ee8e487/plugins/module_utils/podman/quadlet.py#L688-L693