### PR TITLE
podman_login does not support check_mode

### DIFF
--- a/plugins/modules/podman_login.py
+++ b/plugins/modules/podman_login.py
@@ -165,7 +165,7 @@ def main():
             tlsverify=dict(type='bool'),
             secret=dict(type='str', no_log=False),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
         required_by={
             'password': 'username',
         },


### PR DESCRIPTION
The podman_login module does not have code to support check runs. 
Therefore a check run in ansible does the actual login. 
Set supports_check_mode to False so the login is skipped in a dry-run.