### PR TITLE
Fix podman_container_copy examples

### DIFF
--- a/plugins/modules/podman_container_copy.py
+++ b/plugins/modules/podman_container_copy.py
@@ -58,12 +58,12 @@ options:
 
 EXAMPLES = r"""
 - name: Copy file "test.yml" on the host to the "apache" container's root folder
-  containers.podman.podman_search:
+  containers.podman.podman_container_copy:
     src: test.yml
     dest: /
     container: apache
 - name: Copy file "test.yml" in the "apache" container's root folder to the playbook's folder
-  containers.podman.podman_search:
+  containers.podman.podman_container_copy:
     src: /test.yml
     dest: ./
     container: apache


### PR DESCRIPTION
The podman_container_copy examples use the podman_search module