### PR TITLE
Fix typo in example usage for podman_container_copy

### DIFF
--- a/plugins/modules/podman_container_copy.py
+++ b/plugins/modules/podman_container_copy.py
@@ -58,12 +58,12 @@ options:
 
 EXAMPLES = r"""
 - name: Copy file "test.yml" on the host to the "apache" container's root folder
-  containers.podman.podman_search:
+  containers.podman.podman_container_copy:
     src: test.yml
     dest: /
     container: apache
 - name: Copy file "test.yml" in the "apache" container's root folder to the playbook's folder
-  containers.podman.podman_search:
+  containers.podman.podman_container_copy:
     src: /test.yml
     dest: ./
     container: apache


### PR DESCRIPTION
This PR fixes a typo in the [examples](https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_copy_module.html#examples) for `podman_container_copy`

I see there's another PR at https://github.com/containers/ansible-podman-collections/pull/882 but it isn't signed off correctly and the author hasn't responded for some time. This commit is signed off.