### PR TITLE
Use usedforsecurity for hashlib.sha256 only in python version >=3.9

### DIFF
--- a/plugins/modules/podman_image.py
+++ b/plugins/modules/podman_image.py
@@ -432,6 +432,7 @@ import shlex  # noqa: E402
 import tempfile  # noqa: E402
 import time  # noqa: E402
 import hashlib  # noqa: E402
+import sys  # noqa: E402
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
@@ -555,10 +556,17 @@ class PodmanImageManager(object):
         """
         if not containerfile_contents:
             return None
-        return hashlib.sha256(
-            containerfile_contents.encode(),
-            usedforsecurity=False
-        ).hexdigest()
+
+        # usedforsecurity keyword arg was introduced in python 3.9
+        if sys.version_info < (3, 9):
+            return hashlib.sha256(
+                containerfile_contents.encode(),
+            ).hexdigest()
+        else:
+            return hashlib.sha256(
+                containerfile_contents.encode(),
+                usedforsecurity=False
+            ).hexdigest()
 
     def _get_args_containerfile_hash(self):
         """


### PR DESCRIPTION
The usedforsecurity keyword argument of the hashlib functions was introduced in python 3.9. To achieve compatibility with versions below that, we only use it once it is available.

The usedforsecurity argument forces use of secure hash functions in specially compiled versions of python. In this case it would force to upgrade sha256 to a different hash function should sha256 be deemeed insecure in the future. The podman hash we are comparing against is (currently) always sha256.

As sha256 is still considered secure, removing this option for older python versions should be acceptable.

Related Issues: #902 