### PR TITLE
fix(podman_prune): set top-level changed status

### DIFF
--- a/plugins/modules/podman_prune.py
+++ b/plugins/modules/podman_prune.py
@@ -252,7 +252,7 @@ def main():
         results[target] = podmanExec(module, target, system_filters, executable)
 
     # Calculate global changed status from all targets
-    changed = any(results[k].get("changed", False) for k in results)
+    changed = any(res.get("changed", False) for res in results.values())
 
     module.exit_json(changed=changed, **results)
 


### PR DESCRIPTION
## Problem

  The `podman_prune` module always reports `changed: false` at the task level, even when images/containers/volumes are actually deleted.

  This happens because `changed` is returned inside nested dicts, but Ansible expects it at the top level of the result.

  **Current behavior:**
  ```yaml
  # Module returns:
  {"image": {"changed": true, "image": ["sha256:..."]}}
  # Ansible sees: changed=false (no top-level "changed" key)

  Expected behavior:
  # Module should return:
  {"changed": true, "image": {"changed": true, "image": ["sha256:..."]}}
  # Ansible sees: changed=true

  Solution

  Calculate global changed status from all nested results before calling exit_json().

  Testing

  Tested locally with podman 5.7.0:

  Before fix:
  TASK [Prune unused images] *****
  ok: [localhost]

  PLAY RECAP *****
  changed=0

  After fix:
  TASK [Prune unused images] *****
  changed: [localhost]

  PLAY RECAP *****
  changed=1