### PR TITLE
Fix quadlet_options placement when restart_policy is set (#1017)

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -95,8 +95,23 @@ class Quadlet:
         """
         custom_user_options = self.custom_params.get("quadlet_options")
 
+        # Separate quadlet_options into main-section options (plain key=value)
+        # and extra sections (containing section headers like [Install])
+        main_section_options = []
+        extra_section_options = []
+        if custom_user_options:
+            for opt in custom_user_options:
+                if opt.lstrip().startswith("["):
+                    extra_section_options.append(opt)
+                else:
+                    main_section_options.append(opt)
+
         # Build main section
         content = f"[{self.section}]\n" + "\n".join(f"{key}={value}" for key, value in self.dict_params)
+
+        # Append plain key=value quadlet_options to the main section
+        if main_section_options:
+            content += "\n" + "\n".join(main_section_options)
 
         # Add Service section if there are service parameters
         # Check if user hasn't already added a [Service] section in quadlet_options
@@ -108,8 +123,11 @@ class Quadlet:
             service_text = "\n\n[Service]\n" + "\n".join(f"{key}={value}" for key, value in self.service_section.items())
             content += service_text
 
-        custom_text = "\n" + "\n".join(custom_user_options) if custom_user_options else ""
-        return content + custom_text + "\n"
+        # Append extra section options (e.g. [Install] blocks) after the Service section
+        if extra_section_options:
+            content += "\n\n" + "\n".join(extra_section_options)
+
+        return content + "\n"
 
     def write_to_file(self, path: str):
         """

--- a/tests/integration/targets/podman_container/tasks/main.yml
+++ b/tests/integration/targets/podman_container/tasks/main.yml
@@ -1614,7 +1614,73 @@
           - "'--restart' not in quad_custom_service_content.stdout"
         fail_msg: "Should have exactly one [Service] section when user provides custom one"
 
-    - name: Cleanup restart test Quadlet files
+    # Test for issue #1017: quadlet_options should not be moved into [Service] section
+    - name: Create Quadlet with restart_policy and quadlet_options containing plain options
+      containers.podman.podman_container:
+        executable: "{{ test_executable | default('podman') }}"
+        name: container-quadlet-options-order
+        image: alpine
+        state: quadlet
+        quadlet_dir: /tmp
+        restart_policy: always
+        quadlet_options:
+          - AutoUpdate=registry
+          - |
+            [Install]
+            WantedBy=default.target
+      register: quad_options_order
+
+    - name: Read Quadlet file for options order test
+      slurp:
+        src: /tmp/container-quadlet-options-order.container
+      register: quad_options_order_content
+
+    - name: Verify quadlet_options are placed in correct sections
+      vars:
+        content: "{{ quad_options_order_content.content | b64decode }}"
+      assert:
+        that:
+          - quad_options_order is changed
+          - "'AutoUpdate=registry' in content"
+          - "'[Service]' in content"
+          - "'Restart=always' in content"
+          - "'[Install]' in content"
+          - "'WantedBy=default.target' in content"
+          - "content.index('AutoUpdate=registry') < content.index('[Service]')"
+          - "content.index('[Service]') < content.index('[Install]')"
+        fail_msg: "Plain quadlet_options like AutoUpdate should be in [Container] section, not after [Service]"
+
+    - name: Create Quadlet without restart_policy but with quadlet_options
+      containers.podman.podman_container:
+        executable: "{{ test_executable | default('podman') }}"
+        name: container-quadlet-options-no-restart
+        image: alpine
+        state: quadlet
+        quadlet_dir: /tmp
+        quadlet_options:
+          - AutoUpdate=registry
+          - |
+            [Install]
+            WantedBy=default.target
+      register: quad_no_restart
+
+    - name: Read Quadlet file without restart_policy
+      slurp:
+        src: /tmp/container-quadlet-options-no-restart.container
+      register: quad_no_restart_content
+
+    - name: Verify quadlet_options work correctly without restart_policy
+      vars:
+        content: "{{ quad_no_restart_content.content | b64decode }}"
+      assert:
+        that:
+          - quad_no_restart is changed
+          - "'AutoUpdate=registry' in content"
+          - "'[Service]' not in content"
+          - "'[Install]' in content"
+        fail_msg: "quadlet_options without restart_policy should not create a [Service] section"
+
+    - name: Cleanup restart and quadlet_options test files
       file:
         path: "{{ item }}"
         state: absent
@@ -1623,6 +1689,8 @@
         - /tmp/container-restart-on-failure.container
         - /tmp/container-restart-unless-stopped.container
         - /tmp/container-restart-custom-service.container
+        - /tmp/container-quadlet-options-order.container
+        - /tmp/container-quadlet-options-no-restart.container
 
   always:
 


### PR DESCRIPTION
Plain key=value quadlet_options (e.g. AutoUpdate=registry) were placed after the [Service] section, making them part of [Service] instead of [Container]. Split quadlet_options into plain options (appended to the main section) and section blocks (appended after [Service]). Fix #1017

# Type of change

Please select the type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [ ] Other: _____

## Description

Brief description of the changes...

## Motivation and context

Why is this change required? What problem does it solve?

Fixes issue #___

## How has this been tested?

Describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other: _____

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes thoroughly
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I used AI tools, I have disclosed their use in the description of my changes and reviewed the output for accuracy

## Breaking changes

If this is a breaking change, describe what breaks and how to migrate:

## Additional notes

Any additional information or notes for reviewers:
