### PR TITLE
Fix/podman pod check mode support

### DIFF
--- a/plugins/modules/podman_pod.py
+++ b/plugins/modules/podman_pod.py
@@ -701,7 +701,7 @@ from ..module_utils.podman.podman_pod_lib import ARGUMENTS_SPEC_POD  # noqa: F40
 
 
 def main():
-    module = AnsibleModule(argument_spec=ARGUMENTS_SPEC_POD)
+    module = AnsibleModule(argument_spec=ARGUMENTS_SPEC_POD, supports_check_mode=True)
     results = PodmanPodManager(module, module.params).execute()
     module.exit_json(**results)
 

--- a/tests/integration/targets/podman_pod_check_mode/tasks/main.yml
+++ b/tests/integration/targets/podman_pod_check_mode/tasks/main.yml
@@ -1,0 +1,89 @@
+- name: Test podman_pod check mode support
+  block:
+
+    - name: Delete pod1 leftover if any
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: absent
+
+    - name: Create pod in check mode on non-existing pod (should report changed, not skip)
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: created
+      check_mode: true
+      register: pod_check_create
+
+    - name: Assert check mode reported changed and did not skip
+      assert:
+        that:
+          - pod_check_create is changed
+          - pod_check_create is not skipped
+
+    - name: Verify pod was NOT actually created in check mode
+      containers.podman.podman_pod_info:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+      register: pod_check_info
+
+    - name: Assert pod does not exist after check mode run
+      assert:
+        that:
+          - pod_check_info.pods | length == 0
+
+    - name: Create pod for next check mode tests
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: created
+
+    - name: Run check mode on existing pod with same config (should not be changed)
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: created
+      check_mode: true
+      register: pod_check_idempotent
+
+    - name: Assert check mode is idempotent on existing pod
+      assert:
+        that:
+          - pod_check_idempotent is not changed
+          - pod_check_idempotent is not skipped
+
+    - name: Run check mode on existing pod with different config (should report changed)
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: created
+        ports:
+          - "8080:8080"
+      check_mode: true
+      register: pod_check_diff
+
+    - name: Assert check mode reports changed for config diff
+      assert:
+        that:
+          - pod_check_diff is changed
+          - pod_check_diff is not skipped
+
+    - name: Verify pod was NOT actually modified in check mode
+      containers.podman.podman_pod_info:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+      register: pod_after_diff_check
+
+    - name: Assert pod still has no ports after check mode run
+      assert:
+        that:
+          - pod_after_diff_check.pods | length == 1
+          - pod_after_diff_check.pods[0].InfraConfig.PortBindings == {}
+
+  always:
+
+    - name: Cleanup pod1
+      containers.podman.podman_pod:
+        executable: "{{ test_executable | default('podman') }}"
+        name: pod1
+        state: absent


### PR DESCRIPTION
# Type of change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [ ] Other: _____

## Description

Add `supports_check_mode=True` to the AnsibleModule instantiation in podman_pod.py. Without this declaration, Ansible automatically skips the task. when running with `--check`, making it impossible to dry-run any playbook that manages pods. 

The underlying logic in podman_pod_lib.py already guards against execution with if not self.module.check_mode, so the check mode behaviour was fully implemented only the declaration was missing. 
  
## Motivation and context

When running a playbook with `--check`, any task using containers.podman.podman_pod was silently skipped instead of reporting what would change. This makes check mode (dry-run) unusable for playbooks that manage pods.

## How has this been tested?

Describe the tests that you ran to verify your changes:

A dedicated integration test target has been added at tests/integration/targets/podman_pod_check_mode/ covering three scenarios: 

- Check mode on a non-existing pod: reports changed, pod is not actually created
- Check mode on an existing pod with the same config: report not changed (idempotent)
- Check mode on existing pod with a different config: reports changed, pod is not actually modified


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I used AI tools, I have disclosed their use in the description of my changes and reviewed the output for accuracy

## Breaking changes

None. Adding `supports_check_mode=True` only enables check mode support, existing behavior in normal (non-check) runs is unchanged

## Additional notes

This fix was developed with the assistance of Claude cod. All changes have been reviewed, tested locally against a live podman 5.8.1 instance, and sanity-checked with ansible-test sanity.