### PR TITLE
fix podman_secret ignoring `data` if it's an empty string

### DIFF
--- a/plugins/modules/podman_secret.py
+++ b/plugins/modules/podman_secret.py
@@ -143,7 +143,7 @@ def need_update(module, executable, name, data, path, env, skip, driver, driver_
         return False
     try:
         secret = module.from_json(out)[0]
-        if data:
+        if data is not None:
             if secret["SecretData"] != data:
                 if debug:
                     diff["after"] = data
@@ -245,7 +245,7 @@ def podman_secret_create(
             cmd.append("--label")
             cmd.append("=".join([k, v]))
     cmd.append(name)
-    if data:
+    if data is not None:
         cmd.append("-")
     elif path:
         cmd.append(path)
@@ -255,7 +255,7 @@ def podman_secret_create(
         cmd.append("--env")
         cmd.append(env)
 
-    if data:
+    if data is not None:
         rc, out, err = module.run_command(cmd, data=data, binary_data=True)
     else:
         rc, out, err = module.run_command(cmd)


### PR DESCRIPTION
# Type of change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [ ] Other: _____

## Description

fix podman_secret ignoring `data` if it's an empty string

## Motivation and context

While a secret being an empty string is not very useful this breaks with an unhelpful warning "Unable to create secret: Error: accepts 2 arg(s), received 1", and in my case I'm creating the empty secret to simplify deployment and the consumer will be checking if the secret is empty or not (it is more dynamic than podman in this case).

## How has this been tested?

Describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other: _____

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have tested my changes thoroughly
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I used AI tools, I have disclosed their use in the description of my changes and reviewed the output for accuracy

## Breaking changes

If this is a breaking change, describe what breaks and how to migrate:

## Additional notes

Any additional information or notes for reviewers:
