### PR TITLE
Feature/1024 podman prune idempotency

### DIFF
--- a/plugins/modules/podman_prune.py
+++ b/plugins/modules/podman_prune.py
@@ -200,7 +200,7 @@ def podmanExec(module, target, filters, executable):
     if filters is not None:
         command.extend(filtersPrepare(target, filters))
     rc, out, err = module.run_command(command)
-    changed = bool(out)
+    changed = bool(out) and 'Total reclaimed space: 0B' not in out
 
     if rc != 0:
         module.fail_json(msg="Error executing prune on {target}: {err}".format(target=target, err=err))

--- a/plugins/modules/podman_prune.py
+++ b/plugins/modules/podman_prune.py
@@ -200,7 +200,7 @@ def podmanExec(module, target, filters, executable):
     if filters is not None:
         command.extend(filtersPrepare(target, filters))
     rc, out, err = module.run_command(command)
-    changed = bool(out) and 'Total reclaimed space: 0B' not in out
+    changed = bool(out) and ': 0B' not in out
 
     if rc != 0:
         module.fail_json(msg="Error executing prune on {target}: {err}".format(target=target, err=err))

--- a/tests/integration/targets/podman_prune/tasks/main.yml
+++ b/tests/integration/targets/podman_prune/tasks/main.yml
@@ -144,10 +144,12 @@
     # Idempotency - Test "Total reclaimed space: 0B" does not report changed
     - name: Prune objects
       containers.podman.podman_prune:
+        executable: "{{ test_executable | default('podman') }}"
         system: true
 
     - name: Prune objects - 2nd time
       containers.podman.podman_prune:
+        executable: "{{ test_executable | default('podman') }}"
         system: true
       register: podman_prune_result
 

--- a/tests/integration/targets/podman_prune/tasks/main.yml
+++ b/tests/integration/targets/podman_prune/tasks/main.yml
@@ -141,6 +141,21 @@
           # images
           - image_system_exists.images | length == 0
 
+    # Idempotency - Test "Total reclaimed space: 0B" does not report changed
+    - name: Prune objects
+      containers.podman.podman_prune:
+        system: true
+
+    - name: Prune objects - 2nd time
+      containers.podman.podman_prune:
+        system: true
+      register: podman_prune_result
+
+    - name: Assert that result.changed is false
+      ansible.builtin.assert:
+        that:
+          - podman_prune_result.system.changed == false
+
   always:
     - name: Cleanup
       ansible.builtin.command: podman system prune -a -f --volumes


### PR DESCRIPTION
# Type of change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [x] Other: Updating integration checks for bugfix testing

## Description

Disclaimer: I have used a local run LLM (`qwopus3.5-27b-v3.5` ) to generate the fix, but have tested the code manually.

Changed behaviour:

  - If there's no output at all (bool(out) is False) → changed=False (same as before)
  - If output contains ` Total reclaimed space: 0B` → changed=False (new behavior — nothing was pruned)
  - Any other output means resources were actually removed → changed=True

## Motivation and context

Fix reporting changed when `Total reclaimed space: 0B` is reported and no actual cleanup happening.

Why is this change required? What problem does it solve?

Fixes issue #1024

## How has this been tested?

Via local playbook run.

```yaml
        # Idempotency - Test "Total reclaimed space: 0B" does not report changed
        - name: Prune objects
          containers.podman.podman_prune:
            system: true

        - name: Prune objects - 2nd time
          containers.podman.podman_prune:
            system: true
          register: podman_prune_result

        - name: Assert that result.changed is false
          ansible.builtin.assert:
            that:
              - podman_prune_result.system.changed == false
```

Output

```shell
TASK [Prune objects] ***************************************************************************************************************************************************************************
ok: [localhost]

TASK [Prune objects - 2nd time] ****************************************************************************************************************************************************************
ok: [localhost]

TASK [Assert that podman_prune_result.system.changed is false] *********************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}
```

Describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other: _____

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I used AI tools, I have disclosed their use in the description of my changes and reviewed the output for accuracy

## Breaking changes

If this is a breaking change, describe what breaks and how to migrate:

## Additional notes

Any additional information or notes for reviewers:

As described in https://github.com/containers/ansible-podman-collections/issues/1024#issuecomment-4296809306, my python skills rather limited.
So please review carefully. 😇
Thanks in advance.