### PR TITLE
Fix podman_image build ignoring arch (#802)

### DIFF
--- a/plugins/module_utils/podman/podman_image_lib.py
+++ b/plugins/module_utils/podman/podman_image_lib.py
@@ -136,9 +136,9 @@ class PodmanImageBuilder:
         self.executable = executable
         self.auth_config = auth_config or {}
 
-    def build_image(self, image_name, build_config, path=None, containerfile_hash=None, platform=None):
+    def build_image(self, image_name, build_config, path=None, containerfile_hash=None, platform=None, arch=None):
         """Build an image with the given configuration."""
-        args = self._construct_build_args(image_name, build_config, path, containerfile_hash, platform)
+        args = self._construct_build_args(image_name, build_config, path, containerfile_hash, platform, arch)
 
         # Handle inline container file
         temp_file_path = None
@@ -162,14 +162,17 @@ class PodmanImageBuilder:
             if temp_file_path and os.path.exists(temp_file_path):
                 os.remove(temp_file_path)
 
-    def _construct_build_args(self, image_name, build_config, path, containerfile_hash, platform=None):
+    def _construct_build_args(self, image_name, build_config, path, containerfile_hash, platform=None, arch=None):
         """Construct build command arguments."""
         args = ["build", "-t", image_name]
 
         # Add authentication
         self._add_auth_args(args)
 
-        # Add platform for cross-platform builds
+        # Add arch/platform for cross-platform builds
+        if arch:
+            args.extend(["--arch", arch])
+
         if platform:
             args.extend(["--platform", platform])
 
@@ -643,7 +646,8 @@ class PodmanImageManager:
         if not self.module.check_mode:
             image_id, output, podman_command = self.builder.build_image(
                 self.repository.full_name, build_config, path, containerfile_hash,
-                self.params.get("platform")
+                self.params.get("platform"),
+                self.params.get("arch"),
             )
             self.results["stdout"] = output
             self.results["image"] = self.inspector.inspect_image(image_id)

--- a/tests/integration/targets/podman_image/tasks/main.yml
+++ b/tests/integration/targets/podman_image/tasks/main.yml
@@ -676,6 +676,7 @@
 
     - include_tasks: test_issue_947.yml
     - include_tasks: test_issue_981.yml
+    - include_tasks: test_issue_802.yml
 
   always:
     - name: Cleanup images

--- a/tests/integration/targets/podman_image/tasks/test_issue_802.yml
+++ b/tests/integration/targets/podman_image/tasks/test_issue_802.yml
@@ -1,0 +1,44 @@
+---
+# Test for Issue #802: podman_image build doesn't respect arch parameter
+# https://github.com/containers/ansible-podman-collections/issues/802
+- name: Test image architecture for issue #802
+  vars:
+    architectures:
+      - arm64
+      - amd64
+  block:
+    - name: Build image using arch
+      loop: "{{ architectures }}"
+      containers.podman.podman_image:
+        name: "issue-802-arch-{{ item }}"
+        arch: "{{ item }}"
+        state: build
+        build:
+          container_file: |-
+            FROM alpine:latest
+            CMD echo "Built with --arch {{ item }}"
+
+    - name: Build image using platform
+      loop: "{{ architectures }}"
+      containers.podman.podman_image:
+        name: "issue-802-platform-{{ item }}"
+        platform: "linux/{{ item }}"
+        state: build
+        build:
+          container_file: |-
+            FROM alpine:latest
+            CMD echo "Build with --platform linux/{{item}}"
+
+    - name: Inspect built images
+      register: issue_802_result
+      containers.podman.podman_image_info:
+        name: "{{ ['issue-802-arch-', 'issue-802-platform-'] | product(architectures) | map('join') | list }}"
+
+    - name: Verify issue 802 architectures are correct
+      loop: "{{ issue_802_result.images }}"
+      loop_control:
+        label: "{{ item.NamesHistory | first }}.{{ item.Architecture }}"
+      assert:
+        quiet: true
+        fail_msg: "{{ item.NamesHistory | first }} has wrong architecture {{ item.Architecture }}"
+        that: (item.Architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64')) in (item.NamesHistory | first)


### PR DESCRIPTION
# Type of change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [ ] Other: _____

## Description

Add `--arch` to podman build command when the `arch` module parameter is set.

## Motivation and context

The former PR #805 first fixed #802 until a regression was introduced in #957. Both module parameters `platform` and `arch` were working fine before that refactoring. 

Fixes issue #802

## How has this been tested?

Describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other: _____

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I didn’t use AI tools.

## Breaking changes

None.

## Additional notes

None.
