### PR TITLE
Emit InterfaceName for network configs in quadlet mode

### DIFF
--- a/plugins/module_utils/podman/quadlet.py
+++ b/plugins/module_utils/podman/quadlet.py
@@ -482,6 +482,7 @@ class NetworkQuadlet(Quadlet):
         "Label": "Label",
         "global_args": "GlobalArgs",
         "podman_args": "PodmanArgs",
+        "interface_name": "InterfaceName",
     }
 
     def __init__(self, params: dict):

--- a/tests/integration/targets/podman_network/tasks/main.yml
+++ b/tests/integration/targets/podman_network/tasks/main.yml
@@ -725,6 +725,7 @@
     - name: Create quadlet network file
       containers.podman.podman_network:
         executable: "{{ test_executable | default('podman') }}"
+        interface_name: testeth
         name: testnet
         state: quadlet
         disable_dns: true
@@ -758,6 +759,7 @@
       register: line_check
       loop:
         - "[Network]"
+        - "InterfaceName=testeth"
         - "NetworkName=testnet"
         - "Subnet=10.123.12.0"
         - "DisableDNS=true"
@@ -781,6 +783,7 @@
     - name: Create quadlet network file - same
       containers.podman.podman_network:
         executable: "{{ test_executable | default('podman') }}"
+        interface_name: testeth
         name: testnet
         state: quadlet
         disable_dns: true


### PR DESCRIPTION
# Type of change

Please select the type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD improvements
- [ ] Refactoring
- [ ] Other: _____

## Description
The patch fixes the problem that interface_name specified in the podman-network module gets dropped silently instead of being rendered as an InterfaceName entry in the generated .network quadlet file


## Motivation and context
Ran into this issue when i was using the network module to generate a quadlet file for an existing unmanaged bridge. The interface_name got silently dropped in the quadlet file and it took me some time to debug.

Fixes issue #1052

## How has this been tested?

Describe the tests that you ran to verify your changes:

- [ ] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other: _____

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly
- [N/A] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If I used AI tools, I have disclosed their use in the description of my changes and reviewed the output for accuracy

## Breaking changes

If this is a breaking change, describe what breaks and how to migrate:

## Additional notes

I used AI to figure out where the integration test lives and cross check my test cases (it reminded me to add `interface_name` to the idempotency test, which i missed initially)
